### PR TITLE
use GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -46,7 +46,7 @@ jobs:
             TAGS="${DOCKER_IMAGE}_unstable:${GITHUB_SHA},${DOCKER_IMAGE}_unstable:${GIT_BRANCH}-${SHORT_SHA}-${TIMESTAMP},${DOCKER_IMAGE}_unstable:latest"
           fi
           echo "TAGS=${TAGS}"
-          echo "tags::${TAGS}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -46,7 +46,7 @@ jobs:
             TAGS="${DOCKER_IMAGE}_unstable:${GITHUB_SHA},${DOCKER_IMAGE}_unstable:${GIT_BRANCH}-${SHORT_SHA}-${TIMESTAMP},${DOCKER_IMAGE}_unstable:latest"
           fi
           echo "TAGS=${TAGS}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags::${TAGS}" >> $GITHUB_OUTPUT
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
to address
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/