### PR TITLE
Populated inputs section in first step

### DIFF
--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -155,6 +155,7 @@ def iter_single_actions_value_from_query_result(
     evaluations = query_result_item['evaluations']
     elife_doi = query_result_item['elife_doi']
     elife_doi_url = f'{DOI_ROOT_URL}{elife_doi}'
+    # filtered for evalutions for now as we dont have example yet
     if evaluations:
         for evaluation in evaluations:
             hypothesis_id = evaluation["hypothesis_id"]

--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -25,11 +25,8 @@ SCIETY_ARTICLES_EVALUATIONS_URL = 'https://sciety.org/evaluations/hypothesis:'
 
 
 def get_docmap_inputs_value_from_query_result(
-    step_number: int,
     query_result_item: dict
 ) -> list:
-    if step_number == 0:
-        return []
     return [{
         'type': 'preprint',
         'doi': query_result_item['preprint_doi'],
@@ -208,7 +205,6 @@ def generate_docmap_steps(number_of_steps: int, query_result_item: dict) -> dict
                 query_result_item
             ),
             'inputs': get_docmap_inputs_value_from_query_result(
-                step_number,
                 query_result_item
             ),
             'next-step': (

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -68,7 +68,7 @@ def _iter_dict_from_bq_query_mock() -> Iterable[MagicMock]:
 class TestGenerateDocmapSteps:
     def test_should_return_minimum_required_fields_for_a_step(self):
         steps = generate_docmap_steps(1, DOCMAPS_QUERY_RESULT_ITEM_1)
-        assert steps['_:b0']['inputs'] == []
+        assert steps['_:b0']['inputs']
         assert steps['_:b0']['actions']
         assert steps['_:b0']['assertions']
 
@@ -134,14 +134,7 @@ class TestGetDocmapsItemForQueryResultItem:
             DOCMAPS_QUERY_RESULT_ITEM_1['publisher_json']
         )
 
-    def test_should_return_empty_list_for_inputs_in_first_step(self):
-        docmaps_item = get_docmap_item_for_query_result_item(DOCMAPS_QUERY_RESULT_ITEM_1)
-        first_step_key = docmaps_item['first-step']
-        first_step = docmaps_item['steps'][first_step_key]
-        first_step_input = first_step['inputs']
-        assert first_step_input == []
-
-    def test_should_populate_second_step_input_doi_and_url(self):
+    def test_should_populate_first_second_steps_input_doi_and_url(self):
         docmaps_item = get_docmap_item_for_query_result_item(DOCMAPS_QUERY_RESULT_ITEM_1)
         second_step_input = docmaps_item['steps']['_:b1']['inputs']
         assert len(second_step_input) == 1


### PR DESCRIPTION
In previous PR I did remove the input from first step as I was empty in Docmap Examples, But after talking with Scott I realize it is not mandatory to have it as an empty list so I will populate it back as we have the information in first step too.