### PR TITLE
get by doi route for public reviews

### DIFF
--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -363,10 +363,12 @@ class DocmapsProvider:
         if only_include_reviewed_preprint_type:
             self.docmaps_index_query += '\nWHERE is_reviewed_preprint_type'
         if only_include_evaluated_preprints:
-            self.docmaps_index_query += '\nWHERE has_evaluations\nLIMIT 20'
+            self.docmaps_index_query += '\nWHERE has_evaluations'
         self.docmaps_by_preprint_doi_query = (
             self.docmaps_index_query + '\nAND preprint_doi = @preprint_doi'
         )
+        if only_include_evaluated_preprints:
+            self.docmaps_index_query += '\nLIMIT 20'
 
     def iter_docmaps(self, preprint_doi: Optional[str] = None) -> Iterable[dict]:
         if preprint_doi:

--- a/data_hub_api/main.py
+++ b/data_hub_api/main.py
@@ -1,12 +1,34 @@
 import logging
 
-from fastapi import FastAPI, HTTPException
+from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 
 from data_hub_api.docmaps.provider import DocmapsProvider
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+def create_docmaps_router(
+    docmaps_provider: DocmapsProvider
+) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/v1/index")
+    def get_enhanced_preprints_docmaps_index():
+        return docmaps_provider.get_docmaps_index()
+
+    @router.get("/v1/get-by-doi")
+    def get_enhanced_preprints_docmaps_by_preprint_doi(preprint_doi: str):
+        docmaps = docmaps_provider.get_docmaps_by_doi(preprint_doi)
+        if not docmaps:
+            raise HTTPException(
+                status_code=404,
+                detail="No Docmaps available for requested DOI"
+            )
+        return docmaps
+
+    return router
 
 
 def create_app():
@@ -28,22 +50,18 @@ def create_app():
             html_content = file.read()
         return HTMLResponse(content=html_content, status_code=200)
 
-    @app.get("/enhanced-preprints/docmaps/v1/index")
-    def get_enhanced_preprints_docmaps_index():
-        return enhanced_preprints_docmaps_provider.get_docmaps_index()
+    app.include_router(
+        create_docmaps_router(
+            enhanced_preprints_docmaps_provider
+        ),
+        prefix='/enhanced-preprints/docmaps'
+    )
 
-    @app.get("/enhanced-preprints/docmaps/v1/get-by-doi")
-    def get_enhanced_preprints_docmaps_by_preprint_doi(preprint_doi: str):
-        docmaps = enhanced_preprints_docmaps_provider.get_docmaps_by_doi(preprint_doi)
-        if not docmaps:
-            raise HTTPException(
-                status_code=404,
-                detail="No Docmaps available for requested DOI"
-            )
-        return docmaps
-
-    @app.get("/public-reviews/docmaps/v1/index")
-    def get_public_reviews_docmaps_index():
-        return public_reviews_docmaps_provider.get_docmaps_index()
+    app.include_router(
+        create_docmaps_router(
+            public_reviews_docmaps_provider
+        ),
+        prefix='/public-reviews/docmaps'
+    )
 
     return app

--- a/tests/unit_tests/main_test.py
+++ b/tests/unit_tests/main_test.py
@@ -98,6 +98,23 @@ class TestGetEnhancedPreprintsDocmapsIndex:
         response = client.get('/public-reviews/docmaps/v1/index')
         assert response.json() == docmaps_index
 
+    def test_should_return_json_with_docmap_from_public_reviews_provider_for_individual(
+        self,
+        public_reviews_docmaps_provider_mock: MagicMock
+    ):
+        article_docmap_list = [{'id': 'docmap_1'}]
+        public_reviews_docmaps_provider_mock.get_docmaps_by_doi.return_value = (
+            article_docmap_list
+        )
+        client = TestClient(create_app())
+        response = client.get(
+            '/public-reviews/docmaps/v1/get-by-doi',
+            params={'preprint_doi': PREPRINT_DOI}
+        )
+        public_reviews_docmaps_provider_mock.get_docmaps_by_doi.assert_called_with(PREPRINT_DOI)
+        assert response.status_code == 200
+        assert response.json() == article_docmap_list
+
     def test_should_pass_correct_parameters_to_provider_class(
         self,
         enhanced_preprints_docmaps_provider_class_mock: MagicMock


### PR DESCRIPTION
This is useful so that we can look at the Indivdual Docmaps for DOIs that are currently not in enhanced preprints