### PR TITLE
added in-memory BigQuery results cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN pip install --disable-pip-version-check -r requirements.dev.txt
 
 COPY .pylintrc .flake8 mypy.ini ./
 COPY data_hub_api ./data_hub_api
+COPY config ./config
 COPY tests ./tests
 COPY data ./data
 
-CMD [ "python3", "-m", "uvicorn", "data_hub_api.main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]
+CMD [ "python3", "-m", "uvicorn", "data_hub_api.main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000", "--log-config=config/logging.yaml"]

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,13 @@ dev-test: dev-lint dev-unittest
 
 
 dev-start:
-	$(PYTHON) -m uvicorn data_hub_api.main:create_app --reload --factory --host 127.0.0.1 --port 8000
+	$(PYTHON) -m uvicorn \
+		data_hub_api.main:create_app \
+		--reload \
+		--factory \
+		--host 127.0.0.1 \
+		--port 8000 \
+		--log-config=config/logging.yaml
 
 
 build:

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -1,0 +1,22 @@
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  standard:
+    format: "%(asctime)s - %(levelname)s - %(message)s"
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: standard
+    stream: ext://sys.stdout
+
+loggers:
+  uvicorn:
+    error:
+      propagate: true
+
+root:
+  level: INFO
+  handlers: [console]
+  propagate: no

--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -5,6 +5,8 @@ from time import monotonic
 from typing import Iterable, Optional, Sequence
 import urllib
 
+import objsize
+
 from data_hub_api.utils.bigquery import (
     iter_dict_from_bq_query
 )
@@ -399,8 +401,10 @@ class DocmapsProvider:
         ))
         end_time = monotonic()
         LOGGER.info(
-            'Loaded query results from BigQuery, rows=%d, time=%.3f seconds',
-            len(result), (end_time - start_time)
+            'Loaded query results from BigQuery, rows=%d, approx_size=%.3fMB, time=%.3f seconds',
+            len(result),
+            objsize.get_deep_size(result) / 1024 / 1024,
+            (end_time - start_time)
         )
         return result
 

--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -142,6 +142,13 @@ def get_docmap_inputs_value_for_review_steps(
         (evaluation['uri'], evaluation['source_version'])
         for evaluation in query_result_item['evaluations']
     }
+    if not preprint_links_and_versions:
+        LOGGER.error('no preprint link found for doi: %r', query_result_item['preprint_doi'])
+    if len(preprint_links_and_versions) > 1:
+        LOGGER.error(
+            'multiple preprint links found for doi: %r, preprint links: %r',
+            query_result_item['preprint_doi'], preprint_links_and_versions
+        )
     assert len(preprint_links_and_versions) == 1
     preprint_link, preprint_version = next(iter(preprint_links_and_versions))
     return [{

--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -1,6 +1,7 @@
 import logging
 import json
 from pathlib import Path
+from time import monotonic
 from typing import Iterable, Optional, Sequence
 import urllib
 
@@ -392,11 +393,18 @@ class DocmapsProvider:
         self._query_results_cache = query_results_cache
 
     def _load_query_results_from_bq(self) -> Sequence[dict]:
-        LOGGER.info('loading query results from BigQuery')
-        return list(iter_dict_from_bq_query(
+        LOGGER.info('Loading query results from BigQuery...')
+        start_time = monotonic()
+        result = list(iter_dict_from_bq_query(
             self.gcp_project_name,
             self.docmaps_index_query
         ))
+        end_time = monotonic()
+        LOGGER.info(
+            'Loaded query results from BigQuery, rows=%d, time=%.3f seconds',
+            len(result), (end_time - start_time)
+        )
+        return result
 
     def iter_docmaps(self, preprint_doi: Optional[str] = None) -> Iterable[dict]:
         bq_result_list = self._query_results_cache.get_or_load(

--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -385,9 +385,6 @@ class DocmapsProvider:
             self.docmaps_index_query += '\nWHERE is_reviewed_preprint_type'
         if only_include_evaluated_preprints:
             self.docmaps_index_query += '\nWHERE has_evaluations'
-        self.docmaps_by_preprint_doi_query = (
-            self.docmaps_index_query + '\nAND preprint_doi = @preprint_doi'
-        )
         if query_results_cache is None:
             query_results_cache = DummySingleObjectCache[Sequence[dict]]()
         self._query_results_cache = query_results_cache

--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -386,8 +386,6 @@ class DocmapsProvider:
         self.docmaps_by_preprint_doi_query = (
             self.docmaps_index_query + '\nAND preprint_doi = @preprint_doi'
         )
-        if only_include_evaluated_preprints:
-            self.docmaps_index_query += '\nLIMIT 20'
         if query_results_cache is None:
             query_results_cache = DummySingleObjectCache[Sequence[dict]]()
         self._query_results_cache = query_results_cache

--- a/data_hub_api/main.py
+++ b/data_hub_api/main.py
@@ -3,6 +3,7 @@ import logging
 from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 
+from data_hub_api.utils.cache import InMemorySingleObjectCache
 from data_hub_api.docmaps.provider import DocmapsProvider
 
 
@@ -34,14 +35,18 @@ def create_docmaps_router(
 def create_app():
     app = FastAPI()
 
+    max_age_in_seconds = 60 * 60  # 1 hour
+
     enhanced_preprints_docmaps_provider = DocmapsProvider(
         only_include_reviewed_preprint_type=True,
-        only_include_evaluated_preprints=False
+        only_include_evaluated_preprints=False,
+        query_results_cache=InMemorySingleObjectCache(max_age_in_seconds=max_age_in_seconds)
     )
 
     public_reviews_docmaps_provider = DocmapsProvider(
         only_include_reviewed_preprint_type=False,
-        only_include_evaluated_preprints=True
+        only_include_evaluated_preprints=True,
+        query_results_cache=InMemorySingleObjectCache(max_age_in_seconds=max_age_in_seconds)
     )
 
     @app.get("/")

--- a/data_hub_api/main.py
+++ b/data_hub_api/main.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 
 from data_hub_api.utils.cache import InMemorySingleObjectCache
-from data_hub_api.docmaps.provider import DocmapsProvider
+from data_hub_api.docmaps.provider import ADDITIONAL_PREPRINT_DOIS, DocmapsProvider
 
 
 LOGGER = logging.getLogger(__name__)
@@ -40,6 +40,7 @@ def create_app():
     enhanced_preprints_docmaps_provider = DocmapsProvider(
         only_include_reviewed_preprint_type=True,
         only_include_evaluated_preprints=False,
+        additionally_include_preprint_dois=ADDITIONAL_PREPRINT_DOIS,
         query_results_cache=InMemorySingleObjectCache(max_age_in_seconds=max_age_in_seconds)
     )
 

--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -25,11 +25,10 @@ class InMemorySingleObjectCache(SingleObjectCache[T]):
 
     def __init__(
         self,
-        max_age_in_seconds: float,
-        initial_value: Optional[T] = None,
+        max_age_in_seconds: float
     ) -> None:
-        self._value = initial_value
         self.max_age_in_seconds = max_age_in_seconds
+        self._value: Optional[T] = None
         self._last_updated_time: Optional[float] = None
 
     def _is_max_age_reached(self, now: float) -> bool:

--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -16,7 +16,6 @@ class DummySingleObjectCache(SingleObjectCache[T]):
 
 
 class InMemorySingleObjectCache(SingleObjectCache[T]):
-
     def __init__(
         self,
         max_age_in_seconds: float

--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -1,0 +1,30 @@
+from typing import Callable, Optional,  Protocol, TypeVar
+
+
+T = TypeVar('T')
+
+
+class SingleObjectCache(Protocol[T]):
+    def get(self) -> Optional[T]:
+        pass
+
+    def get_or_load(self, load_fn: Callable[[], T]) -> T:
+        pass
+
+
+class SingleObjectInMemoryCache(SingleObjectCache[T]):
+
+    def __init__(self, initial_value: Optional[T] = None) -> None:
+        self._value = initial_value
+
+    def get(self) -> Optional[T]:
+        return self._value
+
+    def get_or_load(self, load_fn: Callable[[], T]) -> T:
+        result = self.get()
+        if result is not None:
+            return result
+        result = load_fn()
+        assert result is not None
+        self._value = result
+        return result

--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -6,17 +6,11 @@ T = TypeVar('T')
 
 
 class SingleObjectCache(Protocol[T]):
-    def get(self) -> Optional[T]:
-        pass
-
     def get_or_load(self, load_fn: Callable[[], T]) -> T:
         pass
 
 
 class DummySingleObjectCache(SingleObjectCache[T]):
-    def get(self) -> Optional[T]:
-        return None
-
     def get_or_load(self, load_fn: Callable[[], T]) -> T:
         return load_fn()
 
@@ -36,9 +30,6 @@ class InMemorySingleObjectCache(SingleObjectCache[T]):
             self._last_updated_time is not None
             and (now - self._last_updated_time > self.max_age_in_seconds)
         )
-
-    def get(self) -> Optional[T]:
-        return self._value
 
     def get_or_load(self, load_fn: Callable[[], T]) -> T:
         now = monotonic()

--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -25,8 +25,8 @@ class InMemorySingleObjectCache(SingleObjectCache[T]):
 
     def __init__(
         self,
+        max_age_in_seconds: float,
         initial_value: Optional[T] = None,
-        max_age_in_seconds: Optional[float] = None
     ) -> None:
         self._value = initial_value
         self.max_age_in_seconds = max_age_in_seconds
@@ -34,8 +34,7 @@ class InMemorySingleObjectCache(SingleObjectCache[T]):
 
     def _is_max_age_reached(self, now: float) -> bool:
         return bool(
-            self.max_age_in_seconds
-            and self._last_updated_time is not None
+            self._last_updated_time is not None
             and (now - self._last_updated_time > self.max_age_in_seconds)
         )
 

--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -21,7 +21,7 @@ class DummySingleObjectCache(SingleObjectCache[T]):
         return load_fn()
 
 
-class SingleObjectInMemoryCache(SingleObjectCache[T]):
+class InMemorySingleObjectCache(SingleObjectCache[T]):
 
     def __init__(
         self,

--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -1,3 +1,4 @@
+from time import monotonic
 from typing import Callable, Optional,  Protocol, TypeVar
 
 
@@ -14,17 +15,32 @@ class SingleObjectCache(Protocol[T]):
 
 class SingleObjectInMemoryCache(SingleObjectCache[T]):
 
-    def __init__(self, initial_value: Optional[T] = None) -> None:
+    def __init__(
+        self,
+        initial_value: Optional[T] = None,
+        max_age_in_seconds: Optional[float] = None
+    ) -> None:
         self._value = initial_value
+        self.max_age_in_seconds = max_age_in_seconds
+        self._last_updated_time: Optional[float] = None
+
+    def _is_max_age_reached(self, now: float) -> bool:
+        return bool(
+            self.max_age_in_seconds
+            and self._last_updated_time is not None
+            and (now - self._last_updated_time > self.max_age_in_seconds)
+        )
 
     def get(self) -> Optional[T]:
         return self._value
 
     def get_or_load(self, load_fn: Callable[[], T]) -> T:
-        result = self.get()
-        if result is not None:
+        now = monotonic()
+        result = self._value
+        if result is not None and not self._is_max_age_reached(now):
             return result
         result = load_fn()
         assert result is not None
         self._value = result
+        self._last_updated_time = now
         return result

--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -13,6 +13,14 @@ class SingleObjectCache(Protocol[T]):
         pass
 
 
+class DummySingleObjectCache(SingleObjectCache[T]):
+    def get(self) -> Optional[T]:
+        return None
+
+    def get_or_load(self, load_fn: Callable[[], T]) -> T:
+        return load_fn()
+
+
 class SingleObjectInMemoryCache(SingleObjectCache[T]):
 
     def __init__(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.88.0
+objsize==0.6.1
 uvicorn[standard]==0.20.0
 google-cloud-bigquery==3.4.1
 pandas==1.5.2

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -6,6 +6,7 @@ import urllib
 
 import pytest
 
+from data_hub_api.utils.cache import InMemorySingleObjectCache
 from data_hub_api.docmaps import provider as provider_module
 from data_hub_api.docmaps.provider import (
     DOCMAP_OUTPUT_TYPE_FOR_AUTHOR_RESPONSE,
@@ -519,6 +520,21 @@ class TestEnhancedPreprintsDocmapsProvider:
             DOCMAPS_QUERY_RESULT_ITEM_1
         ])
         docmaps_index = DocmapsProvider().get_docmaps_index()
+        assert docmaps_index['docmaps'] == [
+            get_docmap_item_for_query_result_item(DOCMAPS_QUERY_RESULT_ITEM_1)
+        ]
+
+    def test_should_cache_docmaps_query_results(
+        self,
+        iter_dict_from_bq_query_mock: MagicMock
+    ):
+        iter_dict_from_bq_query_mock.return_value = [
+            DOCMAPS_QUERY_RESULT_ITEM_1
+        ]
+        docmaps_provider = DocmapsProvider(query_results_cache=InMemorySingleObjectCache())
+        docmaps_provider.get_docmaps_index()
+        docmaps_index = docmaps_provider.get_docmaps_index()
+        assert iter_dict_from_bq_query_mock.call_count == 1
         assert docmaps_index['docmaps'] == [
             get_docmap_item_for_query_result_item(DOCMAPS_QUERY_RESULT_ITEM_1)
         ]

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -557,17 +557,6 @@ class TestEnhancedPreprintsDocmapsProvider:
         )
         assert provider.docmaps_index_query.rstrip().endswith('WHERE has_evaluations')
 
-    def test_should_add_preprint_where_clause_to_query(
-        self
-    ):
-        provider = DocmapsProvider(
-            only_include_reviewed_preprint_type=True,
-            only_include_evaluated_preprints=False
-        )
-        assert provider.docmaps_by_preprint_doi_query.rstrip().endswith(
-            'AND preprint_doi = @preprint_doi'
-        )
-
     def test_should_allow_both_reviewed_prerint_type_and_evaluated_preprints_filter(
         self
     ):

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -521,7 +521,9 @@ class TestEnhancedPreprintsDocmapsProvider:
         iter_dict_from_bq_query_mock.return_value = [
             DOCMAPS_QUERY_RESULT_ITEM_1
         ]
-        docmaps_provider = DocmapsProvider(query_results_cache=InMemorySingleObjectCache())
+        docmaps_provider = DocmapsProvider(
+            query_results_cache=InMemorySingleObjectCache(max_age_in_seconds=10)
+        )
         docmaps_provider.get_docmaps_index()
         docmaps_index = docmaps_provider.get_docmaps_index()
         assert iter_dict_from_bq_query_mock.call_count == 1

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -9,10 +9,10 @@ import pytest
 from data_hub_api.utils.cache import InMemorySingleObjectCache
 from data_hub_api.docmaps import provider as provider_module
 from data_hub_api.docmaps.provider import (
+    ADDITIONAL_PREPRINT_DOIS,
     DOCMAP_OUTPUT_TYPE_FOR_AUTHOR_RESPONSE,
     DOCMAP_OUTPUT_TYPE_FOR_EVALUATION_SUMMARY,
     DOCMAP_OUTPUT_TYPE_FOR_REVIEW_ARTICLE,
-    DOI_ROOT_URL,
     HYPOTHESIS_URL,
     SCIETY_ARTICLES_ACTIVITY_URL,
     SCIETY_ARTICLES_EVALUATIONS_URL,
@@ -349,9 +349,7 @@ class TestGetDocmapsItemForQueryResultItem:
         assert len(peer_reviewed_actions) == 2
         assert peer_reviewed_actions[0]['outputs'][0] == {
             'type': DOCMAP_OUTPUT_TYPE_FOR_REVIEW_ARTICLE,
-            'doi': 'elife_doi_1',
             'published': 'annotation_created_timestamp_1',
-            'url': f'{DOI_ROOT_URL}elife_doi_1',
             'content': [
                 {
                     'type': 'web-page',
@@ -375,9 +373,7 @@ class TestGetDocmapsItemForQueryResultItem:
         }
         assert peer_reviewed_actions[1]['outputs'][0] == {
             'type': DOCMAP_OUTPUT_TYPE_FOR_EVALUATION_SUMMARY,
-            'doi': 'elife_doi_1',
             'published': 'annotation_created_timestamp_2',
-            'url': f'{DOI_ROOT_URL}elife_doi_1',
             'content': [
                 {
                     'type': 'web-page',
@@ -505,12 +501,6 @@ class TestGetDocmapsItemForQueryResultItem:
         ]
 
 
-# class TestGetQueryWithDoiWhereClause:
-#     def test_should_have_where_clause_for_preprint_doi_in_query(self):
-#         query_with_doi_where_clause = DocmapsProvider().get_query_with_doi_where_clause(DOI_1)
-#         assert query_with_doi_where_clause.rstrip().endswith(f'\nAND preprint_doi = {DOI_1}')
-
-
 class TestEnhancedPreprintsDocmapsProvider:
     def test_should_create_index_with_non_empty_docmaps(
         self,
@@ -544,9 +534,22 @@ class TestEnhancedPreprintsDocmapsProvider:
     ):
         provider = DocmapsProvider(
             only_include_reviewed_preprint_type=True,
-            only_include_evaluated_preprints=False
+            only_include_evaluated_preprints=False,
+            additionally_include_preprint_dois=[]
         )
         assert provider.docmaps_index_query.rstrip().endswith('WHERE is_reviewed_preprint_type')
+
+    def test_should_add_additional_preprint_dois_to_query_filter(
+        self
+    ):
+        provider = DocmapsProvider(
+            only_include_reviewed_preprint_type=True,
+            only_include_evaluated_preprints=False,
+            additionally_include_preprint_dois=ADDITIONAL_PREPRINT_DOIS
+        )
+        assert provider.docmaps_index_query.rstrip().endswith(
+            f'OR preprint_doi IN {ADDITIONAL_PREPRINT_DOIS}'
+        )
 
     def test_should_add_has_evaluatons_where_clause_to_query(
         self

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -555,7 +555,7 @@ class TestEnhancedPreprintsDocmapsProvider:
             only_include_reviewed_preprint_type=False,
             only_include_evaluated_preprints=True
         )
-        assert provider.docmaps_index_query.rstrip().endswith('WHERE has_evaluations\nLIMIT 20')
+        assert provider.docmaps_index_query.rstrip().endswith('WHERE has_evaluations')
 
     def test_should_add_preprint_where_clause_to_query(
         self

--- a/tests/unit_tests/main_test.py
+++ b/tests/unit_tests/main_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, patch, MagicMock
+from unittest.mock import ANY, call, patch, MagicMock
 from typing import Iterable, Sequence
 
 import pytest
@@ -124,11 +124,13 @@ class TestGetEnhancedPreprintsDocmapsIndex:
             [
                 call(
                     only_include_reviewed_preprint_type=True,
-                    only_include_evaluated_preprints=False
+                    only_include_evaluated_preprints=False,
+                    query_results_cache=ANY
                 ),
                 call(
                     only_include_reviewed_preprint_type=False,
-                    only_include_evaluated_preprints=True
+                    only_include_evaluated_preprints=True,
+                    query_results_cache=ANY
                 )
             ],
             any_order=False

--- a/tests/unit_tests/main_test.py
+++ b/tests/unit_tests/main_test.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from data_hub_api import main as main_module
+from data_hub_api.docmaps.provider import ADDITIONAL_PREPRINT_DOIS
 from data_hub_api.main import create_app
 
 
@@ -125,6 +126,7 @@ class TestGetEnhancedPreprintsDocmapsIndex:
                 call(
                     only_include_reviewed_preprint_type=True,
                     only_include_evaluated_preprints=False,
+                    additionally_include_preprint_dois=ADDITIONAL_PREPRINT_DOIS,
                     query_results_cache=ANY
                 ),
                 call(

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -16,10 +16,6 @@ def _monotonic_mock() -> Iterable[MagicMock]:
 
 
 class TestInMemorySingleObjectCache:
-    def test_should_get_none_if_not_initialized(self):
-        cache = InMemorySingleObjectCache(max_age_in_seconds=10)
-        assert cache.get() is None
-
     def test_should_get_loaded_value(self):
         cache = InMemorySingleObjectCache(max_age_in_seconds=10)
         result = cache.get_or_load(load_fn=lambda: 'value_1')

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -1,8 +1,18 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+from typing import Iterable
 
+import pytest
+
+import data_hub_api.utils.cache as cache_module
 from data_hub_api.utils.cache import (
     SingleObjectInMemoryCache
 )
+
+
+@pytest.fixture(name='monotonic_mock')
+def _monotonic_mock() -> Iterable[MagicMock]:
+    with patch.object(cache_module, 'monotonic') as mock:
+        yield mock
 
 
 class TestSingleObjectInMemoryCache:
@@ -23,3 +33,16 @@ class TestSingleObjectInMemoryCache:
         result = cache.get_or_load(load_fn=load_fn)
         assert result == 'value_1'
         assert load_fn.call_count == 1
+
+    def test_should_reload_if_max_age_reached(self, monotonic_mock: MagicMock):
+        cache = SingleObjectInMemoryCache[str](
+            max_age_in_seconds=60
+        )
+        load_fn = MagicMock(name='load_fn')
+        load_fn.side_effect = ['value_1', 'value_2']
+        monotonic_mock.return_value = 100
+        cache.get_or_load(load_fn=load_fn)
+        monotonic_mock.return_value = 200
+        result = cache.get_or_load(load_fn=load_fn)
+        assert result == 'value_2'
+        assert load_fn.call_count == 2

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -21,7 +21,7 @@ class TestInMemorySingleObjectCache:
         result = cache.get_or_load(load_fn=lambda: 'value_1')
         assert result == 'value_1'
 
-    def test_should_not_call__load_function_multiple_times(self):
+    def test_should_not_call_load_function_multiple_times(self):
         cache = InMemorySingleObjectCache(max_age_in_seconds=10)
         load_fn = MagicMock(name='load_fn')
         load_fn.return_value = 'value_1'

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -17,16 +17,16 @@ def _monotonic_mock() -> Iterable[MagicMock]:
 
 class TestInMemorySingleObjectCache:
     def test_should_get_none_if_not_initialized(self):
-        cache = InMemorySingleObjectCache()
+        cache = InMemorySingleObjectCache(max_age_in_seconds=10)
         assert cache.get() is None
 
     def test_should_get_loaded_value(self):
-        cache = InMemorySingleObjectCache()
+        cache = InMemorySingleObjectCache(max_age_in_seconds=10)
         result = cache.get_or_load(load_fn=lambda: 'value_1')
         assert result == 'value_1'
 
     def test_should_not_call__load_function_multiple_times(self):
-        cache = InMemorySingleObjectCache()
+        cache = InMemorySingleObjectCache(max_age_in_seconds=10)
         load_fn = MagicMock(name='load_fn')
         load_fn.return_value = 'value_1'
         cache.get_or_load(load_fn=load_fn)

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from data_hub_api.utils.cache import (
+    SingleObjectInMemoryCache
+)
+
+
+class TestSingleObjectInMemoryCache:
+    def test_should_get_none_if_not_initialized(self):
+        cache = SingleObjectInMemoryCache()
+        assert cache.get() is None
+
+    def test_should_get_loaded_value(self):
+        cache = SingleObjectInMemoryCache()
+        result = cache.get_or_load(load_fn=lambda: 'value_1')
+        assert result == 'value_1'
+
+    def test_should_not_call__load_function_multiple_times(self):
+        cache = SingleObjectInMemoryCache()
+        load_fn = MagicMock(name='load_fn')
+        load_fn.return_value = 'value_1'
+        cache.get_or_load(load_fn=load_fn)
+        result = cache.get_or_load(load_fn=load_fn)
+        assert result == 'value_1'
+        assert load_fn.call_count == 1

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -5,7 +5,7 @@ import pytest
 
 import data_hub_api.utils.cache as cache_module
 from data_hub_api.utils.cache import (
-    SingleObjectInMemoryCache
+    InMemorySingleObjectCache
 )
 
 
@@ -15,18 +15,18 @@ def _monotonic_mock() -> Iterable[MagicMock]:
         yield mock
 
 
-class TestSingleObjectInMemoryCache:
+class TestInMemorySingleObjectCache:
     def test_should_get_none_if_not_initialized(self):
-        cache = SingleObjectInMemoryCache()
+        cache = InMemorySingleObjectCache()
         assert cache.get() is None
 
     def test_should_get_loaded_value(self):
-        cache = SingleObjectInMemoryCache()
+        cache = InMemorySingleObjectCache()
         result = cache.get_or_load(load_fn=lambda: 'value_1')
         assert result == 'value_1'
 
     def test_should_not_call__load_function_multiple_times(self):
-        cache = SingleObjectInMemoryCache()
+        cache = InMemorySingleObjectCache()
         load_fn = MagicMock(name='load_fn')
         load_fn.return_value = 'value_1'
         cache.get_or_load(load_fn=load_fn)
@@ -35,7 +35,7 @@ class TestSingleObjectInMemoryCache:
         assert load_fn.call_count == 1
 
     def test_should_reload_if_max_age_reached(self, monotonic_mock: MagicMock):
-        cache = SingleObjectInMemoryCache[str](
+        cache = InMemorySingleObjectCache[str](
             max_age_in_seconds=60
         )
         load_fn = MagicMock(name='load_fn')


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/559

This is a simple cache with some limitations. It's all in memory. It looks like all of the public-reviews take less than 18 MB.
To filter by DOI it is currently scanning the whole list. Although since it is not that long, it doesn't take much time.

Had to make the following unrelated changes:

- logging config, so that we can when we load from BigQuery and the size of the object
- removed hard-coded limit as that prevented it from finding DOIs (as that is now based on the index)