### PR TITLE
fixed the bug for individual DOI pages returning multiple entries

### DIFF
--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -387,6 +387,7 @@ class DocmapsProvider:
         self.docmaps_index_query = (
             Path(get_sql_path('docmaps_index.sql')).read_text(encoding='utf-8')
         )
+        base_docmaps_index_query = self.docmaps_index_query
         assert not (only_include_reviewed_preprint_type and only_include_evaluated_preprints)
         assert not (additionally_include_preprint_dois and not only_include_reviewed_preprint_type)
         if only_include_reviewed_preprint_type:
@@ -396,7 +397,7 @@ class DocmapsProvider:
         if only_include_evaluated_preprints:
             self.docmaps_index_query += '\nWHERE has_evaluations'
         self.docmaps_by_preprint_doi_query = (
-            self.docmaps_index_query + '\nAND preprint_doi = @preprint_doi'
+            base_docmaps_index_query + '\nWHERE preprint_doi = @preprint_doi'
         )
         if only_include_evaluated_preprints:
             self.docmaps_index_query += '\nLIMIT 20'

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -557,7 +557,7 @@ class TestEnhancedPreprintsDocmapsProvider:
             only_include_evaluated_preprints=False
         )
         assert provider.docmaps_by_preprint_doi_query.rstrip().endswith(
-            'AND preprint_doi = @preprint_doi'
+            'WHERE preprint_doi = @preprint_doi'
         )
 
     def test_should_allow_both_reviewed_prerint_type_and_evaluated_preprints_filter(


### PR DESCRIPTION
From Scott:

>  https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi endpoint seems to be returning multiple entries, e.g. https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.06.24.497502 retuning 30 entries.

The reason was `OR` condition in the SQL query and this part of the code has been updated by using the base query variable.