### PR TITLE
updated query to get unmatched manuscript

### DIFF
--- a/data_hub_api/docmaps/sql/docmaps_index.sql
+++ b/data_hub_api/docmaps/sql/docmaps_index.sql
@@ -37,43 +37,12 @@ t_preprint_doi_and_url_by_long_manuscript_identifier AS (
   WHERE rn = 1
 ),
 
-t_editorial_manuscript_version_with_rp_site_data AS (
-  SELECT
-    Version.* EXCEPT(Position, Position_In_Overall_Stage),
-    -- re-calculating Position_In_Overall_Stage using our filters
-    ROW_NUMBER() OVER(
-      PARTITION BY Version.Manuscript_ID, Version.Overall_Stage
-      ORDER BY Version.Version_ID
-    ) AS Position_In_Overall_Stage
-
-  FROM `elife-data-pipeline.prod.mv_Editorial_All_Manuscript_Version` AS Version
-  WHERE Version.Is_Research_Content
-    -- only include manuscripts that went through QC
-    AND Version.QC_Complete_Timestamp IS NOT NULL
-),
-
-t_manuscript_version_with_rp_site_data_last_version AS (
-  SELECT 
-    last_version.*
-  FROM (
-    SELECT 
-      last_version, 
-      ROW_NUMBER() OVER(
-        PARTITION BY last_version.manuscript_id
-        ORDER BY last_version.Version_ID DESC
-      ) AS last_row
-    FROM t_editorial_manuscript_version_with_rp_site_data AS last_version
-  )
-  WHERE last_row = 1
-),
-
-
 t_preprint_doi_and_url_by_manuscript_id AS (
   SELECT
     Version.Manuscript_ID AS manuscript_id,
     preprint_doi_url.*
   FROM t_preprint_doi_and_url_by_long_manuscript_identifier AS preprint_doi_url
-  JOIN t_manuscript_version_with_rp_site_data_last_version AS Version
+  JOIN `elife-data-pipeline.prod.mv_Editorial_Last_Manuscript_Version` AS Version
     ON Version.Long_Manuscript_Identifier = preprint_doi_url.long_manuscript_identifier
 ),
 
@@ -145,16 +114,51 @@ t_hypothesis_annotation_with_doi AS (
   WHERE annotation.group = 'q5X6RWJ6'
 ),
 
-t_initial_result AS (
+t_editorial_manuscript_version_with_rp_site_data AS (
+  SELECT
+    Version.* EXCEPT(Position, Position_In_Overall_Stage),
+    -- re-calculating Position_In_Overall_Stage using our filters
+    ROW_NUMBER() OVER(
+      PARTITION BY Version.Manuscript_ID, Version.Overall_Stage
+      ORDER BY Version.Version_ID
+    ) AS Position_In_Overall_Stage
+
+  FROM `elife-data-pipeline.prod.mv_Editorial_All_Manuscript_Version` AS Version
+  WHERE Version.Is_Research_Content
+    -- only include manuscripts that went through QC
+    AND Version.QC_Complete_Timestamp IS NOT NULL
+),
+
+t_result AS (
   SELECT
     Version.Manuscript_ID AS manuscript_id,
     Version.Long_Manuscript_Identifier AS long_manuscript_identifier,
     Version.QC_Complete_Timestamp AS qc_complete_timestamp,
+  
+    COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi) AS preprint_doi,
+
+    CASE
+      WHEN preprint_doi_and_url.preprint_doi IS NOT NULL THEN 'ejp_preprint_doi'
+      WHEN biorxiv_medrxiv_response.doi IS NOT NULL THEN 'biorxiv_medrxiv_title_match'
+    END AS preprint_doi_source,
 
     IF(preprint_doi_and_url.preprint_url LIKE '%doi.org/%', NULL, preprint_doi_and_url.preprint_url) AS ejp_validated_preprint_url,
     Version.Manuscript_Title AS manuscript_title,
     Version.DOI AS elife_doi,
     (Version.Long_Manuscript_Identifier LIKE '%-RP-%') AS is_reviewed_preprint_type,
+
+    ARRAY(
+      SELECT AS STRUCT
+        annotation.id AS hypothesis_id,
+        annotation.created AS annotation_created_timestamp,
+        annotation.uri,
+        annotation.tags,
+        annotation.normalized_tags,
+        annotation.source_doi,
+        annotation.source_version
+      FROM t_hypothesis_annotation_with_doi AS annotation
+      WHERE annotation.source_doi = COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi)
+    ) AS evaluations,
 
     ARRAY(SELECT Name FROM UNNEST(Version.Reviewing_Editors)) AS editor_names,
     ARRAY(SELECT Name FROM UNNEST(Version.Senior_Editors)) AS senior_editor_names,
@@ -173,29 +177,8 @@ t_initial_result AS (
         '}'
       ],
       '\n'
-    )) AS publisher_json,
+    )) AS publisher_json
 
-    REGEXP_REPLACE(LOWER(Version.Manuscript_Title), r'[^a-z]', '') AS ejp_normalized_title,
-
-    COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi) AS preprint_doi,
-    
-    CASE
-      WHEN preprint_doi_and_url.preprint_doi IS NOT NULL THEN 'ejp_preprint_doi'
-      WHEN biorxiv_medrxiv_response.doi IS NOT NULL THEN 'biorxiv_medrxiv_title_match'
-    END AS preprint_doi_source,
-    
-    ARRAY(
-      SELECT AS STRUCT
-        annotation.id AS hypothesis_id,
-        annotation.created AS annotation_created_timestamp,
-        annotation.uri,
-        annotation.tags,
-        annotation.normalized_tags,
-        annotation.source_doi,
-        annotation.source_version
-      FROM t_hypothesis_annotation_with_doi AS annotation
-      WHERE annotation.source_doi = COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi)
-    ) AS evaluations,
   FROM t_editorial_manuscript_version_with_rp_site_data AS Version
   LEFT JOIN t_preprint_doi_and_url_by_manuscript_id AS preprint_doi_and_url
     ON preprint_doi_and_url.manuscript_id = Version.Manuscript_ID
@@ -204,46 +187,7 @@ t_initial_result AS (
   WHERE
     Version.Overall_Stage = 'Full Submission'
     AND Version.Position_In_Overall_Stage = 1
-),
-
-t_result_with_preprint_dois AS (
-  SELECT 
-    * EXCEPT(ejp_normalized_title)
-  FROM t_initial_result
-  WHERE t_initial_result.preprint_doi IS NOT NULL
-),
-
-t_result_for_partially_match_title AS (
-  SELECT
-    t_initial_result.* EXCEPT(ejp_normalized_title, preprint_doi, preprint_doi_source, evaluations),
-    biorxiv_medrxiv_response.doi AS preprint_doi,
-    'biorxiv_medrxiv_title_match_partial' AS preprint_doi_source,
-    ARRAY(
-        SELECT AS STRUCT
-          annotation.id AS hypothesis_id,
-          annotation.created AS annotation_created_timestamp,
-          annotation.uri,
-          annotation.tags,
-          annotation.normalized_tags,
-          annotation.source_doi,
-          annotation.source_version
-        FROM t_hypothesis_annotation_with_doi AS annotation
-        WHERE annotation.source_doi = biorxiv_medrxiv_response.doi
-      ) AS evaluations,
-  FROM t_biorxiv_medrxiv_response_by_normalized_title AS biorxiv_medrxiv_response
-  INNER JOIN t_initial_result
-    ON biorxiv_medrxiv_response.normalized_title LIKE CONCAT('%', t_initial_result.ejp_normalized_title, '%')
-  WHERE t_initial_result.preprint_doi IS NULL
-  AND t_initial_result.long_manuscript_identifier LIKE '%-RP-%'
-  AND biorxiv_medrxiv_response.doi NOT IN (
-    SELECT preprint_doi FROM t_result_with_preprint_dois
-    )
-),
-
-t_result AS (
-  SELECT * FROM t_result_with_preprint_dois
-  UNION ALL
-  SELECT * FROM t_result_for_partially_match_title
+    AND COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi) IS NOT NULL
 ),
 
 t_result_with_sorted_evaluations AS (
@@ -322,6 +266,7 @@ t_result_with_preprint_published_at_date_and_tdm_path AS (
     ON tdm.tdm_doi = result.preprint_doi
     AND CAST(tdm.tdm_ms_version AS STRING) = result.preprint_version
 )
+
 
 SELECT
   *

--- a/data_hub_api/docmaps/sql/docmaps_index.sql
+++ b/data_hub_api/docmaps/sql/docmaps_index.sql
@@ -37,12 +37,43 @@ t_preprint_doi_and_url_by_long_manuscript_identifier AS (
   WHERE rn = 1
 ),
 
+t_editorial_manuscript_version_with_rp_site_data AS (
+  SELECT
+    Version.* EXCEPT(Position, Position_In_Overall_Stage),
+    -- re-calculating Position_In_Overall_Stage using our filters
+    ROW_NUMBER() OVER(
+      PARTITION BY Version.Manuscript_ID, Version.Overall_Stage
+      ORDER BY Version.Version_ID
+    ) AS Position_In_Overall_Stage
+
+  FROM `elife-data-pipeline.prod.mv_Editorial_All_Manuscript_Version` AS Version
+  WHERE Version.Is_Research_Content
+    -- only include manuscripts that went through QC
+    AND Version.QC_Complete_Timestamp IS NOT NULL
+),
+
+t_manuscript_version_with_rp_site_data_last_version AS (
+  SELECT 
+    last_version.*
+  FROM (
+    SELECT 
+      last_version, 
+      ROW_NUMBER() OVER(
+        PARTITION BY last_version.manuscript_id
+        ORDER BY last_version.Version_ID DESC
+      ) AS last_row
+    FROM t_editorial_manuscript_version_with_rp_site_data AS last_version
+  )
+  WHERE last_row = 1
+),
+
+
 t_preprint_doi_and_url_by_manuscript_id AS (
   SELECT
     Version.Manuscript_ID AS manuscript_id,
     preprint_doi_url.*
   FROM t_preprint_doi_and_url_by_long_manuscript_identifier AS preprint_doi_url
-  JOIN `elife-data-pipeline.prod.mv_Editorial_Last_Manuscript_Version` AS Version
+  JOIN t_manuscript_version_with_rp_site_data_last_version AS Version
     ON Version.Long_Manuscript_Identifier = preprint_doi_url.long_manuscript_identifier
 ),
 
@@ -114,51 +145,16 @@ t_hypothesis_annotation_with_doi AS (
   WHERE annotation.group = 'q5X6RWJ6'
 ),
 
-t_editorial_manuscript_version_with_rp_site_data AS (
-  SELECT
-    Version.* EXCEPT(Position, Position_In_Overall_Stage),
-    -- re-calculating Position_In_Overall_Stage using our filters
-    ROW_NUMBER() OVER(
-      PARTITION BY Version.Manuscript_ID, Version.Overall_Stage
-      ORDER BY Version.Version_ID
-    ) AS Position_In_Overall_Stage
-
-  FROM `elife-data-pipeline.prod.mv_Editorial_All_Manuscript_Version` AS Version
-  WHERE Version.Is_Research_Content
-    -- only include manuscripts that went through QC
-    AND Version.QC_Complete_Timestamp IS NOT NULL
-),
-
-t_result AS (
+t_initial_result AS (
   SELECT
     Version.Manuscript_ID AS manuscript_id,
     Version.Long_Manuscript_Identifier AS long_manuscript_identifier,
     Version.QC_Complete_Timestamp AS qc_complete_timestamp,
-  
-    COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi) AS preprint_doi,
-
-    CASE
-      WHEN preprint_doi_and_url.preprint_doi IS NOT NULL THEN 'ejp_preprint_doi'
-      WHEN biorxiv_medrxiv_response.doi IS NOT NULL THEN 'biorxiv_medrxiv_title_match'
-    END AS preprint_doi_source,
 
     IF(preprint_doi_and_url.preprint_url LIKE '%doi.org/%', NULL, preprint_doi_and_url.preprint_url) AS ejp_validated_preprint_url,
     Version.Manuscript_Title AS manuscript_title,
     Version.DOI AS elife_doi,
     (Version.Long_Manuscript_Identifier LIKE '%-RP-%') AS is_reviewed_preprint_type,
-
-    ARRAY(
-      SELECT AS STRUCT
-        annotation.id AS hypothesis_id,
-        annotation.created AS annotation_created_timestamp,
-        annotation.uri,
-        annotation.tags,
-        annotation.normalized_tags,
-        annotation.source_doi,
-        annotation.source_version
-      FROM t_hypothesis_annotation_with_doi AS annotation
-      WHERE annotation.source_doi = COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi)
-    ) AS evaluations,
 
     ARRAY(SELECT Name FROM UNNEST(Version.Reviewing_Editors)) AS editor_names,
     ARRAY(SELECT Name FROM UNNEST(Version.Senior_Editors)) AS senior_editor_names,
@@ -177,8 +173,29 @@ t_result AS (
         '}'
       ],
       '\n'
-    )) AS publisher_json
+    )) AS publisher_json,
 
+    REGEXP_REPLACE(LOWER(Version.Manuscript_Title), r'[^a-z]', '') AS ejp_normalized_title,
+
+    COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi) AS preprint_doi,
+    
+    CASE
+      WHEN preprint_doi_and_url.preprint_doi IS NOT NULL THEN 'ejp_preprint_doi'
+      WHEN biorxiv_medrxiv_response.doi IS NOT NULL THEN 'biorxiv_medrxiv_title_match'
+    END AS preprint_doi_source,
+    
+    ARRAY(
+      SELECT AS STRUCT
+        annotation.id AS hypothesis_id,
+        annotation.created AS annotation_created_timestamp,
+        annotation.uri,
+        annotation.tags,
+        annotation.normalized_tags,
+        annotation.source_doi,
+        annotation.source_version
+      FROM t_hypothesis_annotation_with_doi AS annotation
+      WHERE annotation.source_doi = COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi)
+    ) AS evaluations,
   FROM t_editorial_manuscript_version_with_rp_site_data AS Version
   LEFT JOIN t_preprint_doi_and_url_by_manuscript_id AS preprint_doi_and_url
     ON preprint_doi_and_url.manuscript_id = Version.Manuscript_ID
@@ -187,7 +204,46 @@ t_result AS (
   WHERE
     Version.Overall_Stage = 'Full Submission'
     AND Version.Position_In_Overall_Stage = 1
-    AND COALESCE(preprint_doi_and_url.preprint_doi, biorxiv_medrxiv_response.doi) IS NOT NULL
+),
+
+t_result_with_preprint_dois AS (
+  SELECT 
+    * EXCEPT(ejp_normalized_title)
+  FROM t_initial_result
+  WHERE t_initial_result.preprint_doi IS NOT NULL
+),
+
+t_result_for_partially_match_title AS (
+  SELECT
+    t_initial_result.* EXCEPT(ejp_normalized_title, preprint_doi, preprint_doi_source, evaluations),
+    biorxiv_medrxiv_response.doi AS preprint_doi,
+    'biorxiv_medrxiv_title_match_partial' AS preprint_doi_source,
+    ARRAY(
+        SELECT AS STRUCT
+          annotation.id AS hypothesis_id,
+          annotation.created AS annotation_created_timestamp,
+          annotation.uri,
+          annotation.tags,
+          annotation.normalized_tags,
+          annotation.source_doi,
+          annotation.source_version
+        FROM t_hypothesis_annotation_with_doi AS annotation
+        WHERE annotation.source_doi = biorxiv_medrxiv_response.doi
+      ) AS evaluations,
+  FROM t_biorxiv_medrxiv_response_by_normalized_title AS biorxiv_medrxiv_response
+  INNER JOIN t_initial_result
+    ON biorxiv_medrxiv_response.normalized_title LIKE CONCAT('%', t_initial_result.ejp_normalized_title, '%')
+  WHERE t_initial_result.preprint_doi IS NULL
+  AND t_initial_result.long_manuscript_identifier LIKE '%-RP-%'
+  AND biorxiv_medrxiv_response.doi NOT IN (
+    SELECT preprint_doi FROM t_result_with_preprint_dois
+    )
+),
+
+t_result AS (
+  SELECT * FROM t_result_with_preprint_dois
+  UNION ALL
+  SELECT * FROM t_result_for_partially_match_title
 ),
 
 t_result_with_sorted_evaluations AS (
@@ -266,7 +322,6 @@ t_result_with_preprint_published_at_date_and_tdm_path AS (
     ON tdm.tdm_doi = result.preprint_doi
     AND CAST(tdm.tdm_ms_version AS STRING) = result.preprint_version
 )
-
 
 SELECT
   *


### PR DESCRIPTION
https://github.com/elifesciences/data-hub-issues/issues/610

From Scott:

> We were expecting a particular preprint to appear in the feed under review ([10.1101/2022.11.18.517042](https://www.biorxiv.org/content/10.1101/2022.11.18.517042v1)), but I’m not seeing it there.
> The eJP ID is 13-12-2022-RA-RP-eLife-85562, but that looks like an older date so this may not be related at all.  Are you able to trace why it’s not showing in the api?