### PR TITLE
Handled null elife_doi

### DIFF
--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -46,12 +46,36 @@ ADDITIONAL_PREPRINT_DOIS = (
 
 
 def get_elife_version_doi(
-    elife_doi: str = None,
-    elife_doi_version_str: str = None
-) -> str:
+    elife_doi_version_str: str,
+    elife_doi: Optional[str] = None
+) -> Optional[str]:
     if not elife_doi:
         return None
     return elife_doi + '.' + elife_doi_version_str
+
+
+def get_elife_evaluation_doi(
+    elife_doi_version_str: str,
+    elife_doi: Optional[str] = None,
+    evaluation_suffix: Optional[str] = None
+) -> Optional[str]:
+    elife_version_doi = get_elife_version_doi(
+        elife_doi=elife_doi,
+        elife_doi_version_str=elife_doi_version_str
+    )
+    if not elife_version_doi:
+        return None
+    if not evaluation_suffix:
+        return elife_version_doi
+    return elife_version_doi + '.' + evaluation_suffix
+
+
+def get_elife_doi_url(
+    elife_evaluation_doi: Optional[str] = None
+) -> Optional[str]:
+    if not elife_evaluation_doi:
+        return None
+    return f'{DOI_ROOT_URL}' + elife_evaluation_doi
 
 
 def get_docmap_assertions_value_for_preprint_manuscript_published_step(
@@ -279,14 +303,11 @@ def get_single_actions_value_for_preprint_peer_reviewed_step(
     outputs_type: str
 ) -> dict:
     preprint_doi = query_result_item['preprint_doi']
-    elife_version_doi = get_elife_version_doi(
+    elife_evaluation_doi = get_elife_evaluation_doi(
+        elife_doi_version_str=query_result_item['elife_doi_version_str'],
         elife_doi=query_result_item['elife_doi'],
-        elife_doi_version_str=query_result_item['elife_doi_version_str']
+        evaluation_suffix=evaluation_suffix
     )
-    if evaluation_suffix:
-        elife_evaluation_doi = elife_version_doi + '.' + evaluation_suffix
-    else:
-        elife_evaluation_doi = elife_version_doi
     return {
         'participants': get_participants_for_preprint_peer_reviewed_step(
             query_result_item=query_result_item,
@@ -297,7 +318,7 @@ def get_single_actions_value_for_preprint_peer_reviewed_step(
                 'type': outputs_type,
                 'published': annotation_created_timestamp,
                 'doi': elife_evaluation_doi,
-                'url': f'{DOI_ROOT_URL}' + elife_evaluation_doi,
+                'url': get_elife_doi_url(elife_evaluation_doi=elife_evaluation_doi),
                 'content': [
                     {
                         'type': 'web-page',

--- a/data_hub_api/docmaps/provider.py
+++ b/data_hub_api/docmaps/provider.py
@@ -46,9 +46,11 @@ ADDITIONAL_PREPRINT_DOIS = (
 
 
 def get_elife_version_doi(
-    elife_doi: str,
-    elife_doi_version_str: str
+    elife_doi: str = None,
+    elife_doi_version_str: str = None
 ) -> str:
+    if not elife_doi:
+        return None
     return elife_doi + '.' + elife_doi_version_str
 
 
@@ -281,7 +283,10 @@ def get_single_actions_value_for_preprint_peer_reviewed_step(
         elife_doi=query_result_item['elife_doi'],
         elife_doi_version_str=query_result_item['elife_doi_version_str']
     )
-    elife_evaluation_doi = elife_version_doi + '.' + evaluation_suffix
+    if evaluation_suffix:
+        elife_evaluation_doi = elife_version_doi + '.' + evaluation_suffix
+    else:
+        elife_evaluation_doi = elife_version_doi
     return {
         'participants': get_participants_for_preprint_peer_reviewed_step(
             query_result_item=query_result_item,

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -22,6 +22,7 @@ from data_hub_api.docmaps.provider import (
     DOCMAPS_JSONLD_SCHEMA_URL,
     DOCMAP_ID_PREFIX,
     generate_docmap_steps,
+    get_elife_version_doi,
     get_outputs_type_form_tags
 )
 
@@ -99,6 +100,20 @@ def get_hypothesis_ids_from_urls(hypothesis_urls: Iterable[str]) -> Iterable[str
         for hypothesis_url in hypothesis_urls
         if hypothesis_url.startswith(HYPOTHESIS_URL)
     ]
+
+
+class TestGetElifeVersionDoi:
+    def test_should_return_doi_with_version_when_the_version_defined(self):
+        elife_doi = 'elife_doi_1'
+        elife_doi_version_str = 'elife_doi_version_str_1'
+        actual_result = get_elife_version_doi(elife_doi, elife_doi_version_str)
+        assert actual_result == 'elife_doi_1.elife_doi_version_str_1'
+
+    def test_should_return_doi_without_version_when_the_doi_not_defined(self):
+        elife_doi = ''
+        elife_doi_version_str = 'elife_doi_version_str_1'
+        actual_result = get_elife_version_doi(elife_doi, elife_doi_version_str)
+        assert not actual_result
 
 
 class TestGetOutputsTypeFromTags:

--- a/tests/unit_tests/docmaps/provider_test.py
+++ b/tests/unit_tests/docmaps/provider_test.py
@@ -22,6 +22,8 @@ from data_hub_api.docmaps.provider import (
     DOCMAPS_JSONLD_SCHEMA_URL,
     DOCMAP_ID_PREFIX,
     generate_docmap_steps,
+    get_elife_doi_url,
+    get_elife_evaluation_doi,
     get_elife_version_doi,
     get_outputs_type_form_tags
 )
@@ -106,13 +108,66 @@ class TestGetElifeVersionDoi:
     def test_should_return_doi_with_version_when_the_version_defined(self):
         elife_doi = 'elife_doi_1'
         elife_doi_version_str = 'elife_doi_version_str_1'
-        actual_result = get_elife_version_doi(elife_doi, elife_doi_version_str)
+        actual_result = get_elife_version_doi(
+            elife_doi=elife_doi,
+            elife_doi_version_str=elife_doi_version_str
+        )
         assert actual_result == 'elife_doi_1.elife_doi_version_str_1'
 
     def test_should_return_doi_without_version_when_the_doi_not_defined(self):
         elife_doi = ''
         elife_doi_version_str = 'elife_doi_version_str_1'
-        actual_result = get_elife_version_doi(elife_doi, elife_doi_version_str)
+        actual_result = get_elife_version_doi(
+            elife_doi=elife_doi,
+            elife_doi_version_str=elife_doi_version_str
+        )
+        assert not actual_result
+
+
+class TestGetElifeEvaluationDoi:
+    def test_should_return_evaluation_doi_with_suffix_if_defined(self):
+        elife_doi = 'elife_doi_1'
+        elife_doi_version_str = 'elife_doi_version_str_1'
+        evaluation_suffix = 'evaluation_suffix_1'
+        actual_result = get_elife_evaluation_doi(
+            elife_doi=elife_doi,
+            elife_doi_version_str=elife_doi_version_str,
+            evaluation_suffix=evaluation_suffix
+        )
+        assert actual_result == 'elife_doi_1.elife_doi_version_str_1.evaluation_suffix_1'
+
+    def test_should_return_evaluation_doi_without_suffix_if_not_defined(self):
+        elife_doi = 'elife_doi_1'
+        elife_doi_version_str = 'elife_doi_version_str_1'
+        evaluation_suffix = ''
+        actual_result = get_elife_evaluation_doi(
+            elife_doi=elife_doi,
+            elife_doi_version_str=elife_doi_version_str,
+            evaluation_suffix=evaluation_suffix
+        )
+        assert actual_result == 'elife_doi_1.elife_doi_version_str_1'
+
+    def test_should_return_none_if_elife_doi_not_defined(self):
+        elife_doi = ''
+        elife_doi_version_str = 'elife_doi_version_str_1'
+        evaluation_suffix = ''
+        actual_result = get_elife_evaluation_doi(
+            elife_doi=elife_doi,
+            elife_doi_version_str=elife_doi_version_str,
+            evaluation_suffix=evaluation_suffix
+        )
+        assert not actual_result
+
+
+class TestGetElifeDoiUrl:
+    def test_should_return_url_with_elife_doi(self):
+        elife_evaluation_doi = 'elife_evaluation_doi_1'
+        actual_result = get_elife_doi_url(elife_evaluation_doi=elife_evaluation_doi)
+        assert actual_result == f'{DOI_ROOT_URL}elife_evaluation_doi_1'
+
+    def test_should_return_none_if_elife_evaluation_doi_not_defined(self):
+        elife_evaluation_doi = ''
+        actual_result = get_elife_doi_url(elife_evaluation_doi=elife_evaluation_doi)
         assert not actual_result
 
 


### PR DESCRIPTION
```
  File "/Users/hazal/elife_repo/data-hub-api/venv/lib/python3.8/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "/Users/hazal/elife_repo/data-hub-api/venv/lib/python3.8/site-packages/anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/Users/hazal/elife_repo/data-hub-api/venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "/Users/hazal/elife_repo/data-hub-api/venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "./data_hub_api/main.py", line 20, in get_enhanced_preprints_docmaps_index
    return docmaps_provider.get_docmaps_index()
  File "./data_hub_api/docmaps/provider.py", line 476, in get_docmaps_index
    article_docmaps_list = list(self.iter_docmaps())
  File "./data_hub_api/docmaps/provider.py", line 470, in iter_docmaps
    yield get_docmap_item_for_query_result_item(bq_result)
  File "./data_hub_api/docmaps/provider.py", line 412, in get_docmap_item_for_query_result_item
    'steps': generate_docmap_steps(iter_docmap_steps_for_query_result_item(query_result_item))
  File "./data_hub_api/docmaps/provider.py", line 388, in generate_docmap_steps
    step_list = list(step_itearble)
  File "./data_hub_api/docmaps/provider.py", line 381, in iter_docmap_steps_for_query_result_item
    yield get_docmaps_step_for_under_review_status(query_result_item)
  File "./data_hub_api/docmaps/provider.py", line 167, in get_docmaps_step_for_under_review_status
    'actions': get_docmap_actions_value_for_preprint_under_review_step(
  File "./data_hub_api/docmaps/provider.py", line 144, in get_docmap_actions_value_for_preprint_under_review_step
    'doi': get_elife_version_doi(
  File "./data_hub_api/docmaps/provider.py", line 52, in get_elife_version_doi
    return elife_doi + '.' + elife_doi_version_str
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```