### PR TITLE
Reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8 AS base
 
 USER root
+ENV PIP_NO_CACHE_DIR=1
 
 WORKDIR /app/api
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8 AS base
+FROM python:3.8-slim AS base
 
 USER root
 ENV PIP_NO_CACHE_DIR=1


### PR DESCRIPTION
This does two changes:

1. disable pip cache for Dockerfile runs - saves about 50mb
2. switch to debian slim python base image - saves > 700mb

I've started the server and it's running, but I don't have credentials to do more than that for testing.

fixes https://github.com/elifesciences/issues/issues/8213