### PR TITLE
Fix the bug with dateutil.parser._parser.ParserError

### DIFF
--- a/data_hub_api/docmaps/v2/codecs/elife_manuscript.py
+++ b/data_hub_api/docmaps/v2/codecs/elife_manuscript.py
@@ -71,9 +71,12 @@ def get_docmap_elife_manuscript_output_for_published_step(
             query_result_item,
             manuscript_version
         ),
-        # 'published': manuscript_version['rp_publication_timestamp']
-        'published': format_datetime_with_utc_offset(
-            date_string=str(manuscript_version['rp_publication_timestamp'])
+        'published': (
+            format_datetime_with_utc_offset(
+                date_string=str(manuscript_version['rp_publication_timestamp'])
+            )
+            if manuscript_version['rp_publication_timestamp']
+            else None
         )
     }
 

--- a/data_hub_api/utils/format_datetime.py
+++ b/data_hub_api/utils/format_datetime.py
@@ -6,22 +6,23 @@ def format_datetime_with_utc_offset(
     date_string: str,
     date_format: str = "%Y-%m-%dT%H:%M:%S%z"
 ):
+    if date_string:
+        if isinstance(date_string, datetime):
+            date_string = date_string.strftime("%Y-%m-%dT%H:%M:%S%z")
 
-    if isinstance(date_string, datetime):
-        date_string = date_string.strftime("%Y-%m-%dT%H:%M:%S%z")
+        dt_object = parse(date_string)
 
-    dt_object = parse(date_string)
+        # Set the UTC timezone explicitly
+        dt_object_utc = dt_object.replace(tzinfo=timezone.utc)
 
-    # Set the UTC timezone explicitly
-    dt_object_utc = dt_object.replace(tzinfo=timezone.utc)
+        # Convert to the desired timezone (UTC) with the colon in the UTC offset
+        dt_object_with_tz = dt_object_utc.astimezone(timezone.utc)
 
-    # Convert to the desired timezone (UTC) with the colon in the UTC offset
-    dt_object_with_tz = dt_object_utc.astimezone(timezone.utc)
+        # Format the datetime object with the correct UTC offset format
+        formatted_date_string = dt_object_with_tz.strftime(date_format)
 
-    # Format the datetime object with the correct UTC offset format
-    formatted_date_string = dt_object_with_tz.strftime(date_format)
+        # Manually add the colon in the UTC offset
+        formatted_date_string = formatted_date_string[:-2] + ":" + formatted_date_string[-2:]
 
-    # Manually add the colon in the UTC offset
-    formatted_date_string = formatted_date_string[:-2] + ":" + formatted_date_string[-2:]
-
-    return formatted_date_string
+        return formatted_date_string
+    return None

--- a/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
+++ b/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
@@ -84,10 +84,30 @@ class TestGetDocmapElifeManuscriptOutputForPublishedStep:
         )
         assert result == {
             'type': 'preprint',
-            # 'published': RP_PUBLICATION_TIMESTAMP_1,
             'published': format_datetime_with_utc_offset(
                 date_string=RP_PUBLICATION_TIMESTAMP_1
             ),
+            'identifier': DOCMAPS_QUERY_RESULT_ITEM_1['manuscript_id'],
+            'doi': get_elife_manuscript_version_doi(
+                elife_doi_version_str=MANUSCRIPT_VERSION_1['elife_doi_version_str'],
+                elife_doi=DOCMAPS_QUERY_RESULT_ITEM_1['elife_doi']
+            ),
+            'versionIdentifier': MANUSCRIPT_VERSION_1['elife_doi_version_str'],
+            'license': DOCMAPS_QUERY_RESULT_ITEM_1['license']
+        }
+
+    def test_should_not_populate_published_if_rp_publication_timestamp_is_none(self):
+        manuscript_version = {
+            **MANUSCRIPT_VERSION_1,
+            'rp_publication_timestamp': None
+        }
+        result = get_docmap_elife_manuscript_output_for_published_step(
+            query_result_item=DOCMAPS_QUERY_RESULT_ITEM_1,
+            manuscript_version=manuscript_version
+        )
+        assert result == {
+            'type': 'preprint',
+            'published': None,
             'identifier': DOCMAPS_QUERY_RESULT_ITEM_1['manuscript_id'],
             'doi': get_elife_manuscript_version_doi(
                 elife_doi_version_str=MANUSCRIPT_VERSION_1['elife_doi_version_str'],

--- a/tests/unit_tests/utils/format_datetime_test.py
+++ b/tests/unit_tests/utils/format_datetime_test.py
@@ -19,3 +19,9 @@ class TestFormatDatetimeWithUtcOffset:
             date_string='2023-05-05T01:02:03+00:00'
         )
         assert result == '2023-05-05T01:02:03+00:00'
+
+    def test_should_return_none_when_the_datetime_string_is_none(self):
+        result = format_datetime_with_utc_offset(
+            date_string=None
+        )
+        assert not result


### PR DESCRIPTION
```2023-07-20 09:01:16,750 - ERROR - Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/uvicorn/protocols/http/httptools_impl.py", line 419, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.8/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/uvicorn/middleware/message_logger.py", line 86, in __call__
    raise exc from None
  File "/usr/local/lib/python3.8/site-packages/uvicorn/middleware/message_logger.py", line 82, in __call__
    await self.app(scope, inner_receive, inner_send)
  File "/usr/local/lib/python3.8/site-packages/fastapi/applications.py", line 270, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/usr/local/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 706, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/usr/local/lib/python3.8/site-packages/fastapi/routing.py", line 235, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.8/site-packages/fastapi/routing.py", line 163, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/usr/local/lib/python3.8/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "/usr/local/lib/python3.8/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/usr/local/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/usr/local/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/app/api/./data_hub_api/docmaps/v2/api_router.py", line 22, in get_enhanced_preprints_docmaps_by_manuscript_id_by_publisher_elife
    docmaps = docmaps_provider.get_docmaps_by_manuscript_id(manuscript_id)
  File "/app/api/./data_hub_api/docmaps/v2/provider.py", line 71, in get_docmaps_by_manuscript_id
    return list(self.iter_docmaps_by_manuscript_id(manuscript_id))
  File "/app/api/./data_hub_api/docmaps/v2/provider.py", line 68, in iter_docmaps_by_manuscript_id
    yield get_docmap_item_for_query_result_item(cast(ApiInput, bq_result))
  File "/app/api/./data_hub_api/docmaps/v2/codecs/docmaps.py", line 325, in get_docmap_item_for_query_result_item
    'steps': generate_docmap_steps(iter_docmap_steps_for_query_result_item(query_result_item))
  File "/app/api/./data_hub_api/docmaps/v2/codecs/docmaps.py", line 298, in generate_docmap_steps
    step_list = list(step_iterable)
  File "/app/api/./data_hub_api/docmaps/v2/codecs/docmaps.py", line 282, in iter_docmap_steps_for_query_result_item
    yield get_docmaps_step_for_manuscript_published_status(
  File "/app/api/./data_hub_api/docmaps/v2/codecs/docmaps.py", line 203, in get_docmaps_step_for_manuscript_published_status
    'actions': get_docmap_actions_for_manuscript_published_step(
  File "/app/api/./data_hub_api/docmaps/v2/codecs/docmaps.py", line 175, in get_docmap_actions_for_manuscript_published_step
    'outputs': [get_docmap_elife_manuscript_output_for_published_step(
  File "/app/api/./data_hub_api/docmaps/v2/codecs/elife_manuscript.py", line 75, in get_docmap_elife_manuscript_output_for_published_step
    'published': format_datetime_with_utc_offset(
  File "/app/api/./data_hub_api/utils/format_datetime.py", line 13, in format_datetime_with_utc_offset
    dt_object = parse(date_string)
  File "/usr/local/lib/python3.8/site-packages/dateutil/parser/_parser.py", line 1368, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/dateutil/parser/_parser.py", line 643, in parse
    raise ParserError("Unknown string format: %s", timestr)
dateutil.parser._parser.ParserError: Unknown string format: None
```