### PR TITLE
Fix the date order for annotation rank

### DIFF
--- a/data_hub_api/docmaps/v2/sql/docmaps_index.sql
+++ b/data_hub_api/docmaps/v2/sql/docmaps_index.sql
@@ -66,7 +66,7 @@ t_manual_osf_preprint_match AS (
 t_hypothesis_annotation_for_osf_preprints AS (
   SELECT 
     *,
-    DENSE_RANK() OVER (PARTITION BY extracted_osf_id ORDER BY annotation_created_date DESC) AS osf_preprint_version_rank
+    DENSE_RANK() OVER (PARTITION BY extracted_osf_id ORDER BY annotation_created_date) AS osf_preprint_version_rank
   FROM t_hypothesis_annotation_with_doi
   WHERE uri LIKE '%psyarxiv%'
 ),


### PR DESCRIPTION
From Fred:
> the authors of 87271 have pointed out that the reviews are on the wrong versions (reviews for version 2 are on the version 1 and reviews for version 1 are on the version 2). Any idea how we can fix this?