### PR TITLE
Separate meca path with reviews

### DIFF
--- a/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
@@ -26,13 +26,7 @@
                             "identifier": "80984",
                             "doi": "10.7554/eLife.80984.1",
                             "versionIdentifier": "1",
-                            "license": "http://creativecommons.org/licenses/by/4.0/",
-                            "content": [
-                                {
-                                    "type": "computer-file",
-                                    "url": "s3://elife-s3-bucket/manuscript-rp-12345-v1.meca"
-                                }
-                            ]
+                            "license": "http://creativecommons.org/licenses/by/4.0/"
                         }
                     ]
                 }

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
@@ -26,7 +26,13 @@
                             "identifier": "80984",
                             "doi": "10.7554/eLife.80984.1",
                             "versionIdentifier": "1",
-                            "license": "http://creativecommons.org/licenses/by/4.0/"
+                            "license": "http://creativecommons.org/licenses/by/4.0/",
+                            "content": [
+                                {
+                                    "type": "computer-file",
+                                    "url": "s3://elife-s3-bucket/manuscript-rp-12345-v1.meca"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -312,7 +318,13 @@
                                         "title": "Listen to Stacey Harmer explain how sunflowers coordinate their flowering patterns."
                                     }
                                 ]
-                            }
+                            },
+                            "content": [
+                                {
+                                    "type": "computer-file",
+                                    "url": "s3://elife-s3-bucket/manuscript-rp-with-reviews-12345-v1.meca"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
@@ -316,7 +316,7 @@
                             "content": [
                                 {
                                     "type": "computer-file",
-                                    "url": "s3://elife-s3-bucket/manuscript-rp-with-reviews-12345-v1.meca"
+                                    "url": "s3://prod-elife-epp-meca/reviewed-preprints/86284-v1-meca.zip"
                                 }
                             ]
                         }

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
@@ -256,8 +256,11 @@
                 }, {
                     "participants": [],
                     "outputs": [{
-                        "type": "computer-file",
+                        "type": "preprint",
+                        "identifier": "80984",
                         "doi": "10.7554/eLife.80984.1",
+                        "versionIdentifier": "1",
+                        "license": "http://creativecommons.org/licenses/by/4.0/",
                         "content": [
                             {
                                 "type": "computer-file",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
@@ -253,6 +253,18 @@
                             ]
                         }
                     ]
+                }, {
+                    "participants": [],
+                    "outputs": [{
+                        "type": "computer-file",
+                        "doi": "10.7554/eLife.80984.1",
+                        "content": [
+                            {
+                                "type": "computer-file",
+                                "url": "s3://prod-elife-epp-meca/reviewed-preprints/86284-v1-meca.zip"
+                            }
+                        ]
+                    }]
                 }
             ],
             "assertions": [
@@ -312,13 +324,7 @@
                                         "title": "Listen to Stacey Harmer explain how sunflowers coordinate their flowering patterns."
                                     }
                                 ]
-                            },
-                            "content": [
-                                {
-                                    "type": "computer-file",
-                                    "url": "s3://prod-elife-epp-meca/reviewed-preprints/86284-v1-meca.zip"
-                                }
-                            ]
+                            }
                         }
                     ]
                 }


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/919
part of https://github.com/elifesciences/data-hub-issues/issues/914

This is the draft DocMap change that we discussed during the meeting.

Open questions:

- Is the meca path going to be the same
- What should the exact meca path be?

Note: Not meant to merge this PR as the file is used for regression tests (and need to be implemented first)