### PR TITLE
feat: Add identifier to result of elife_manuscript_test

### DIFF
--- a/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
@@ -365,6 +365,7 @@
                     "outputs": [
                         {
                             "type": "version-of-record",
+                            "identifier": "80984",
                             "doi": "10.7554/eLife.80984.2",
                             "published": "2023-01-13",
                             "url": "https://doi.org/10.7554/eLife.80984.2",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/84553.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/84553.json
@@ -316,6 +316,7 @@
             "outputs": [
               {
                 "type": "version-of-record",
+                "identifier": "84553",
                 "doi": "10.7554/eLife.84553.2",
                 "published": "2023-12-28",
                 "url": "https://doi.org/10.7554/eLife.84553.2",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/85596.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/85596.json
@@ -654,6 +654,7 @@
             "outputs": [
               {
                 "type": "version-of-record",
+                "identifier": "85596",
                 "doi": "10.7554/eLife.85596.3",
                 "published": "2023-07-20",
                 "url": "https://doi.org/10.7554/eLife.85596.3",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/86628.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/86628.json
@@ -502,6 +502,7 @@
           "outputs": [
             {
               "type": "version-of-record",
+              "identifier": "86628",
               "doi": "10.7554/eLife.86628.3",
               "published": "2023-06-02",
               "url": "https://doi.org/10.7554/eLife.86628.3",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/86824.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/86824.json
@@ -638,6 +638,7 @@
             "outputs": [
             {
                 "type": "version-of-record",
+                "identifier": "86824",
                 "doi": "10.7554/eLife.86824.3",
                 "published": "2023-10-17",
                 "url": "https://doi.org/10.7554/eLife.86824.3",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/86873.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/86873.json
@@ -580,6 +580,7 @@
                     "outputs": [
                         {
                             "type": "version-of-record",
+                            "identifier": "86873",
                             "doi": "10.7554/eLife.86873.3",
                             "published": "2023-12-11",
                             "url": "https://doi.org/10.7554/eLife.86873.3",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/87193.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/87193.json
@@ -684,6 +684,7 @@
                     "outputs": [
                         {
                             "type": "version-of-record",
+                            "identifier": "87193",
                             "doi": "10.7554/eLife.87193.3",
                             "published": "2023-10-11",
                             "url": "https://doi.org/10.7554/eLife.87193.3",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/87198.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/87198.json
@@ -594,6 +594,7 @@
                     "outputs": [
                         {
                             "type": "version-of-record",
+                            "identifier": "87198",
                             "doi": "10.7554/eLife.87198.3",
                             "published": "2023-12-22",
                             "url": "https://doi.org/10.7554/eLife.87198.3",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/88266.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/88266.json
@@ -606,6 +606,7 @@
                     "outputs": [
                         {
                             "type": "version-of-record",
+                            "identifier": "88266",
                             "doi": "10.7554/eLife.88266.3",
                             "published": "2023-12-07",
                             "url": "https://doi.org/10.7554/eLife.88266.3",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/88984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/88984.json
@@ -1006,6 +1006,7 @@
                     "outputs": [
                         {
                             "type": "version-of-record",
+                            "identifier": "88984",
                             "doi": "10.7554/eLife.88984.4",
                             "url": "https://doi.org/10.7554/eLife.88984.4",
                             "published": "2024-01-19",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/89891.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/89891.json
@@ -684,6 +684,7 @@
                     "outputs": [
                         {
                             "type": "version-of-record",
+                            "identifier": "89891",
                             "doi": "10.7554/eLife.89891.3",
                             "published": "2023-12-11",
                             "url": "https://doi.org/10.7554/eLife.89891.3",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/91729.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/91729.json
@@ -558,6 +558,7 @@
             "outputs": [
               {
                 "type": "version-of-record",
+                "identifier": "91729",
                 "doi": "10.7554/eLife.91729.3",
                 "published": "2024-04-05",
                 "url": "https://doi.org/10.7554/eLife.91729.3",

--- a/data_hub_api/docmaps/v2/codecs/elife_manuscript.py
+++ b/data_hub_api/docmaps/v2/codecs/elife_manuscript.py
@@ -73,7 +73,8 @@ def get_docmap_elife_manuscript_doi_assertion_item_for_vor(
             manuscript_version=manuscript_version,
             is_vor=True
         ),
-        'type': 'version-of-record'
+        'type': 'version-of-record',
+        'identifier': query_result_item['manuscript_id']
     }
 
 
@@ -247,6 +248,7 @@ def get_docmap_elife_manuscript_output_for_vor(
     )
     return {
         'type': 'version-of-record',
+        'identifier': query_result_item['manuscript_id'],
         'doi': manuscript_version_doi,
         'published': (
             manuscript_version['vor_publication_date'].isoformat()

--- a/data_hub_api/docmaps/v2/codecs/elife_manuscript.py
+++ b/data_hub_api/docmaps/v2/codecs/elife_manuscript.py
@@ -73,8 +73,7 @@ def get_docmap_elife_manuscript_doi_assertion_item_for_vor(
             manuscript_version=manuscript_version,
             is_vor=True
         ),
-        'type': 'version-of-record',
-        'identifier': query_result_item['manuscript_id']
+        'type': 'version-of-record'
     }
 
 

--- a/data_hub_api/docmaps/v2/docmap_typing.py
+++ b/data_hub_api/docmaps/v2/docmap_typing.py
@@ -89,6 +89,7 @@ DocmapElifeManuscriptVorOutput = TypedDict(
     'DocmapElifeManuscriptVorOutput',
     {
         'type': str,
+        'identifier': str,
         'doi': str,
         'published': Optional[date_str],
         'url': str,

--- a/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
+++ b/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
@@ -79,7 +79,6 @@ class TestGetDocmapElifeManuscriptDoiAssertionItemForVor:
         )
         assert result == {
             'type': 'version-of-record',
-            'identifier': DOCMAPS_QUERY_RESULT_ITEM_1['manuscript_id'],
             'doi': get_elife_manuscript_version_doi(
                 elife_doi_version_str=MANUSCRIPT_VERSION_1['elife_doi_version_str'],
                 elife_doi=DOCMAPS_QUERY_RESULT_ITEM_1['elife_doi'],

--- a/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
+++ b/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
@@ -79,6 +79,7 @@ class TestGetDocmapElifeManuscriptDoiAssertionItemForVor:
         )
         assert result == {
             'type': 'version-of-record',
+            'identifier': DOCMAPS_QUERY_RESULT_ITEM_1['manuscript_id'],
             'doi': get_elife_manuscript_version_doi(
                 elife_doi_version_str=MANUSCRIPT_VERSION_1['elife_doi_version_str'],
                 elife_doi=DOCMAPS_QUERY_RESULT_ITEM_1['elife_doi'],
@@ -348,6 +349,7 @@ class TestGetDocmapElifeManuscriptOutputForVor:
         )
         assert result == {
             'type': 'version-of-record',
+            'identifier': DOCMAPS_QUERY_RESULT_ITEM_WITH_VOR_VERSION['manuscript_id'],
             'doi': manuscript_version_doi,
             'published': VOR_PUBLICATION_DATE_1.isoformat(),
             'url': f'{DOI_ROOT_URL}' + manuscript_version_doi,


### PR DESCRIPTION
This commit includes the addition of 'identifier' to the result of the elife_manuscript_test in the docmaps v2 codec. The identifier is sourced from the DOCMAPS_QUERY_RESULT_ITEM and DOCMAPS_QUERY_RESULT_ITEM_WITH_VOR_VERSION respectively.