### PR TITLE
Add versionIdentifier to vor output

### DIFF
--- a/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
@@ -367,6 +367,7 @@
                             "type": "version-of-record",
                             "identifier": "80984",
                             "doi": "10.7554/eLife.80984.2",
+                            "versionIdentifier": "2",
                             "published": "2023-01-13",
                             "url": "https://doi.org/10.7554/eLife.80984.2",
                             "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/84553.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/84553.json
@@ -318,6 +318,7 @@
                 "type": "version-of-record",
                 "identifier": "84553",
                 "doi": "10.7554/eLife.84553.2",
+                "versionIdentifier": "2",
                 "published": "2023-12-28",
                 "url": "https://doi.org/10.7554/eLife.84553.2",
                 "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/85596.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/85596.json
@@ -656,6 +656,7 @@
                 "type": "version-of-record",
                 "identifier": "85596",
                 "doi": "10.7554/eLife.85596.3",
+                "versionIdentifier": "3",
                 "published": "2023-07-20",
                 "url": "https://doi.org/10.7554/eLife.85596.3",
                 "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/86628.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/86628.json
@@ -504,6 +504,7 @@
               "type": "version-of-record",
               "identifier": "86628",
               "doi": "10.7554/eLife.86628.3",
+              "versionIdentifier": "3",
               "published": "2023-06-02",
               "url": "https://doi.org/10.7554/eLife.86628.3",
               "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/86824.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/86824.json
@@ -640,6 +640,7 @@
                 "type": "version-of-record",
                 "identifier": "86824",
                 "doi": "10.7554/eLife.86824.3",
+                "versionIdentifier": "3",
                 "published": "2023-10-17",
                 "url": "https://doi.org/10.7554/eLife.86824.3",
                 "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/86873.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/86873.json
@@ -582,6 +582,7 @@
                             "type": "version-of-record",
                             "identifier": "86873",
                             "doi": "10.7554/eLife.86873.3",
+                            "versionIdentifier": "3",
                             "published": "2023-12-11",
                             "url": "https://doi.org/10.7554/eLife.86873.3",
                             "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/87193.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/87193.json
@@ -686,6 +686,7 @@
                             "type": "version-of-record",
                             "identifier": "87193",
                             "doi": "10.7554/eLife.87193.3",
+                            "versionIdentifier": "3",
                             "published": "2023-10-11",
                             "url": "https://doi.org/10.7554/eLife.87193.3",
                             "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/87198.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/87198.json
@@ -596,6 +596,7 @@
                             "type": "version-of-record",
                             "identifier": "87198",
                             "doi": "10.7554/eLife.87198.3",
+                            "versionIdentifier": "3",
                             "published": "2023-12-22",
                             "url": "https://doi.org/10.7554/eLife.87198.3",
                             "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/88266.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/88266.json
@@ -608,6 +608,7 @@
                             "type": "version-of-record",
                             "identifier": "88266",
                             "doi": "10.7554/eLife.88266.3",
+                            "versionIdentifier": "3",
                             "published": "2023-12-07",
                             "url": "https://doi.org/10.7554/eLife.88266.3",
                             "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/88984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/88984.json
@@ -1008,6 +1008,7 @@
                             "type": "version-of-record",
                             "identifier": "88984",
                             "doi": "10.7554/eLife.88984.4",
+                            "versionIdentifier": "4",
                             "url": "https://doi.org/10.7554/eLife.88984.4",
                             "published": "2024-01-19",
                             "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/89891.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/89891.json
@@ -686,6 +686,7 @@
                             "type": "version-of-record",
                             "identifier": "89891",
                             "doi": "10.7554/eLife.89891.3",
+                            "versionIdentifier": "3",
                             "published": "2023-12-11",
                             "url": "https://doi.org/10.7554/eLife.89891.3",
                             "content": [

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/91729.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/91729.json
@@ -560,6 +560,7 @@
                 "type": "version-of-record",
                 "identifier": "91729",
                 "doi": "10.7554/eLife.91729.3",
+                "versionIdentifier": "3",
                 "published": "2024-04-05",
                 "url": "https://doi.org/10.7554/eLife.91729.3",
                 "content": [

--- a/data_hub_api/docmaps/v2/codecs/elife_manuscript.py
+++ b/data_hub_api/docmaps/v2/codecs/elife_manuscript.py
@@ -249,6 +249,10 @@ def get_docmap_elife_manuscript_output_for_vor(
         'type': 'version-of-record',
         'identifier': query_result_item['manuscript_id'],
         'doi': manuscript_version_doi,
+        'versionIdentifier': get_elife_manuscript_version(
+             manuscript_version['elife_doi_version_str'],
+             is_vor
+         ),
         'published': (
             manuscript_version['vor_publication_date'].isoformat()
             if manuscript_version['vor_publication_date']

--- a/data_hub_api/docmaps/v2/docmap_typing.py
+++ b/data_hub_api/docmaps/v2/docmap_typing.py
@@ -91,6 +91,7 @@ DocmapElifeManuscriptVorOutput = TypedDict(
         'type': str,
         'identifier': str,
         'doi': str,
+        'versionIdentifier': str,
         'published': Optional[date_str],
         'url': str,
         'content': Sequence[DocmapContent]

--- a/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
+++ b/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
@@ -350,6 +350,7 @@ class TestGetDocmapElifeManuscriptOutputForVor:
             'type': 'version-of-record',
             'identifier': DOCMAPS_QUERY_RESULT_ITEM_WITH_VOR_VERSION['manuscript_id'],
             'doi': manuscript_version_doi,
+            'versionIdentifier': MANUSCRIPT_VERSION_WITH_EVALUATIONS_AND_VOR_1['elife_doi_version_str'],
             'published': VOR_PUBLICATION_DATE_1.isoformat(),
             'url': f'{DOI_ROOT_URL}' + manuscript_version_doi,
             'content': [{

--- a/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
+++ b/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
@@ -350,7 +350,9 @@ class TestGetDocmapElifeManuscriptOutputForVor:
             'type': 'version-of-record',
             'identifier': DOCMAPS_QUERY_RESULT_ITEM_WITH_VOR_VERSION['manuscript_id'],
             'doi': manuscript_version_doi,
-            'versionIdentifier': MANUSCRIPT_VERSION_WITH_EVALUATIONS_AND_VOR_1['elife_doi_version_str'],
+            'versionIdentifier': MANUSCRIPT_VERSION_WITH_EVALUATIONS_AND_VOR_1[
+                'elife_doi_version_str'
+            ],
             'published': VOR_PUBLICATION_DATE_1.isoformat(),
             'url': f'{DOI_ROOT_URL}' + manuscript_version_doi,
             'content': [{

--- a/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
+++ b/tests/unit_tests/docmaps/v2/codecs/elife_manuscript_test.py
@@ -350,9 +350,12 @@ class TestGetDocmapElifeManuscriptOutputForVor:
             'type': 'version-of-record',
             'identifier': DOCMAPS_QUERY_RESULT_ITEM_WITH_VOR_VERSION['manuscript_id'],
             'doi': manuscript_version_doi,
-            'versionIdentifier': MANUSCRIPT_VERSION_WITH_EVALUATIONS_AND_VOR_1[
-                'elife_doi_version_str'
-            ],
+            'versionIdentifier': get_elife_manuscript_version(
+                MANUSCRIPT_VERSION_WITH_EVALUATIONS_AND_VOR_1[
+                    'elife_doi_version_str'
+                ],
+                is_vor=True
+            ),
             'published': VOR_PUBLICATION_DATE_1.isoformat(),
             'url': f'{DOI_ROOT_URL}' + manuscript_version_doi,
             'content': [{


### PR DESCRIPTION
Regression tests are passing for me locally.

This helps with the following issue: https://github.com/elifesciences/enhanced-preprints-issues/issues/1079