### PR TITLE
Handle not available vor_update_timestamp

### DIFF
--- a/data_hub_api/docmaps/v2/codecs/docmaps.py
+++ b/data_hub_api/docmaps/v2/codecs/docmaps.py
@@ -236,11 +236,10 @@ def get_docmap_assertions_for_vor_steps(
         'status': 'vor-published'
     }
     if vor_version_number > 1:
-        assert vor_updated_timestamp
         return [{
             **assertion,  # type: ignore
             'status': 'corrected',
-            'happened': vor_updated_timestamp.isoformat()
+            'happened': (vor_updated_timestamp.isoformat() if vor_updated_timestamp else None)
         }]
     return [assertion]
 

--- a/data_hub_api/docmaps/v2/docmap_typing.py
+++ b/data_hub_api/docmaps/v2/docmap_typing.py
@@ -182,7 +182,7 @@ DocmapAssertion = TypedDict(
     {
         'item': DocmapAssertionItem,
         'status': str,
-        'happened': NotRequired[str]
+        'happened': NotRequired[Optional[str]]
     },
     total=False
 )

--- a/tests/unit_tests/docmaps/v2/codecs/docmaps_test.py
+++ b/tests/unit_tests/docmaps/v2/codecs/docmaps_test.py
@@ -176,7 +176,7 @@ class TestGetDocmapAssertionsForVorSteps:
         assertion_status = assertion_list[0]['status']
         assertion_happened = assertion_list[0]['happened']
         assert assertion_status == 'corrected'
-        assert not assertion_happened
+        assert assertion_happened is None
 
 
 class TestGetDocmapsItemForQueryResultItem:

--- a/tests/unit_tests/docmaps/v2/codecs/docmaps_test.py
+++ b/tests/unit_tests/docmaps/v2/codecs/docmaps_test.py
@@ -166,6 +166,18 @@ class TestGetDocmapAssertionsForVorSteps:
         assert assertion_status == 'corrected'
         assert assertion_happened == VOR_UPDATED_TIMESTAMP_2.isoformat()
 
+    def test_should_populate_assertion_happened_with_none_if_updated_timestamp_not_available(self):
+        assertion_list = get_docmap_assertions_for_vor_steps(
+            query_result_item=DOCMAPS_QUERY_RESULT_ITEM_WITH_VOR_VERSIONS_2,
+            manuscript_version=MANUSCRIPT_VERSION_WITH_EVALUATIONS_1,
+            vor_version_number=VOR_VERSIONS_2['vor_version_number'],
+            vor_updated_timestamp=None
+        )
+        assertion_status = assertion_list[0]['status']
+        assertion_happened = assertion_list[0]['happened']
+        assert assertion_status == 'corrected'
+        assert not assertion_happened
+
 
 class TestGetDocmapsItemForQueryResultItem:
     def test_should_populate_context(self):


### PR DESCRIPTION
Removed assertion error for not available vor update date instead we will not populate that field until it is available

https://github.com/elifesciences/data-hub-issues/issues/943