### PR TITLE
Update `docker compose` command in make file for ci tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-DOCKER_COMPOSE_DEV = docker-compose
-DOCKER_COMPOSE_CI = docker-compose -f docker-compose.yml
+DOCKER_COMPOSE_DEV = docker compose
+DOCKER_COMPOSE_CI = docker compose -f docker-compose.yml
 DOCKER_COMPOSE = $(DOCKER_COMPOSE_DEV)
 
 VENV = venv


### PR DESCRIPTION
Currently `docker-compose` command is not working because of the depreciation to `docker compose`. 

Related logs:

```
##[debug]Evaluating condition for step: 'Build Image'
##[debug]Evaluating: success()
##[debug]Evaluating success:
##[debug]=> true
##[debug]Result: true
##[debug]Starting: Build Image
##[debug]Loading inputs
##[debug]Loading env
Run make build
##[debug]/usr/bin/bash -e /home/runner/work/_temp/13e04[2](https://github.com/elifesciences/data-hub-api/actions/runs/10961091880/job/30437673591#step:3:2)b9-a769-4b66-bb0e-6175cc63ff08.sh
docker-compose build data-hub-api
make: docker-compose: No such file or directory
make: *** [Makefile:82: build] Error 12[7](https://github.com/elifesciences/data-hub-api/actions/runs/10961091880/job/30437673591#step:3:7)
Error: Process completed with exit code 2.
##[debug]Finishing: Build Image
```