### PR TITLE
Log full url when logging request received

### DIFF
--- a/data_hub_api/utils/fastapi.py
+++ b/data_hub_api/utils/fastapi.py
@@ -27,13 +27,13 @@ def log_requests_middleware():
         )
         protocol = request.scope.get('http_version', 'unknown')
         method = request.method
-        path = request.url.path
+        url = request.url
 
         request_id_context_var.set(request_id)
 
         LOGGER.info(
             '%s',
-            f'Received request: {client_addr} "{method} {path} HTTP/{protocol}" "{user_agent}"'
+            f'Received request: {client_addr} "{method} {url} HTTP/{protocol}" "{user_agent}"'
         )
 
         response = await call_next(request)


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1205

The query parameters where missing.
Using the `url` was the easiest way to fix it.
This then also includes the hostname which may have other benefits.