### PR TITLE
Added logging around streaming docmaps index

### DIFF
--- a/data_hub_api/docmaps/v2/provider.py
+++ b/data_hub_api/docmaps/v2/provider.py
@@ -72,12 +72,18 @@ class DocmapsProvider:
         return list(self.iter_docmaps_by_manuscript_id(manuscript_id))
 
     def iter_docmaps_index_json_stream(self):
-        yield '{"docmaps":['
-        first = True
-        for docmap in self.iter_docmaps_by_manuscript_id():
-            if not first:
-                yield ','
-            else:
-                first = False
-            yield json.dumps(docmap)
-        yield ']}'
+        LOGGER.info('Streaming docmaps index as JSON...')
+        try:
+            yield '{"docmaps":['
+            first = True
+            for docmap in self.iter_docmaps_by_manuscript_id():
+                if not first:
+                    yield ','
+                else:
+                    first = False
+                yield json.dumps(docmap)
+            yield ']}'
+        except Exception as e:
+            LOGGER.exception('Error while streaming docmaps index as JSON: %s', e)
+            raise
+        LOGGER.info('Finished streaming docmaps index as JSON.')


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1206

This will be useful because the header HTTP 200 will get sent to the client before it has completed providing the response.


```text
2025-09-09 15:45:16,614 - INFO - 1dbc639b-54a9-426f-932d-a432ad68ba19 - Received request: 127.0.0.1:51142 "GET http://localhost:8000/enhanced-preprints/docmaps/v2/index HTTP/1.1" "curl/8.5.0"
2025-09-09 15:45:16,615 - INFO - 1dbc639b-54a9-426f-932d-a432ad68ba19 - 127.0.0.1:51142 - "GET /enhanced-preprints/docmaps/v2/index HTTP/1.1" 200
2025-09-09 15:45:16,616 - INFO - 1dbc639b-54a9-426f-932d-a432ad68ba19 - Streaming docmaps index as JSON...
2025-09-09 15:45:21,726 - INFO - 1dbc639b-54a9-426f-932d-a432ad68ba19 - Finished streaming docmaps index as JSON.
```