### PR TITLE
Allow special characters in regression test data

### DIFF
--- a/data/docmaps/regression_test/docmap_by_manuscript_id/104779.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/104779.json
@@ -218,9 +218,9 @@
                         {
                             "actor": {
                                 "type": "person",
-                                "name": "Christian B\u00fcchel",
+                                "name": "Christian Büchel",
                                 "firstName": "Christian",
-                                "surname": "B\u00fcchel",
+                                "surname": "Büchel",
                                 "_relatesToOrganization": "University Medical Center Hamburg-Eppendorf, Germany",
                                 "affiliation": {
                                     "id": "https://ror.org/01zgy1s35",
@@ -552,9 +552,9 @@
                         {
                             "actor": {
                                 "type": "person",
-                                "name": "Christian B\u00fcchel",
+                                "name": "Christian Büchel",
                                 "firstName": "Christian",
-                                "surname": "B\u00fcchel",
+                                "surname": "Büchel",
                                 "_relatesToOrganization": "University Medical Center Hamburg-Eppendorf, Germany",
                                 "affiliation": {
                                     "id": "https://ror.org/01zgy1s35",
@@ -568,9 +568,9 @@
                         {
                             "actor": {
                                 "type": "person",
-                                "name": "Christian B\u00fcchel",
+                                "name": "Christian Büchel",
                                 "firstName": "Christian",
-                                "surname": "B\u00fcchel",
+                                "surname": "Büchel",
                                 "_relatesToOrganization": "University Medical Center Hamburg-Eppendorf, Germany",
                                 "affiliation": {
                                     "id": "https://ror.org/01zgy1s35",

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/80984.json
@@ -191,8 +191,8 @@
                         {
                             "actor": {
                                 "type": "person",
-                                "name": "J\u00fcrgen Kleine-Vehn",
-                                "firstName": "J\u00fcrgen",
+                                "name": "Jürgen Kleine-Vehn",
+                                "firstName": "Jürgen",
                                 "surname": "Kleine-Vehn",
                                 "_relatesToOrganization": "University of Freiburg, Germany",
                                 "affiliation": {

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/84553.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/84553.json
@@ -169,8 +169,8 @@
                             "actor": {
                                 "type": "person",
                                 "id": "https://orcid.org/0000-0002-0796-4473",
-                                "name": "Mar\u00eda Zambrano",
-                                "firstName": "Mar\u00eda",
+                                "name": "María Zambrano",
+                                "firstName": "María",
                                 "_middleName": "Mercedes",
                                 "surname": "Zambrano",
                                 "_relatesToOrganization": "CorpoGen, Colombia",
@@ -178,7 +178,7 @@
                                     "id": "https://ror.org/03npzn484",
                                     "type": "organization",
                                     "name": "CorpoGen",
-                                    "location": "Bogot\u00e1, Colombia"
+                                    "location": "Bogotá, Colombia"
                                 }
                             },
                             "role": "editor"
@@ -189,11 +189,11 @@
                                 "name": "Detlef Weigel",
                                 "firstName": "Detlef",
                                 "surname": "Weigel",
-                                "_relatesToOrganization": "Max Planck Institute for Biology T\u00fcbingen, Germany",
+                                "_relatesToOrganization": "Max Planck Institute for Biology Tübingen, Germany",
                                 "affiliation": {
                                     "type": "organization",
-                                    "name": "Max Planck Institute for Biology T\u00fcbingen",
-                                    "location": "T\u00fcbingen, Germany"
+                                    "name": "Max Planck Institute for Biology Tübingen",
+                                    "location": "Tübingen, Germany"
                                 }
                             },
                             "role": "senior-editor"

--- a/data/docmaps/regression_test/docmap_by_manuscript_id/87198.json
+++ b/data/docmaps/regression_test/docmap_by_manuscript_id/87198.json
@@ -147,10 +147,10 @@
                                 "firstName": "David",
                                 "_middleName": "A.",
                                 "surname": "Paz-Garcia",
-                                "_relatesToOrganization": "Centro de Investigaciones Biol\u00f3gicas del Noroeste (CIBNOR), Mexico",
+                                "_relatesToOrganization": "Centro de Investigaciones Biológicas del Noroeste (CIBNOR), Mexico",
                                 "affiliation": {
                                     "type": "organization",
-                                    "name": "Centro de Investigaciones Biol\u00f3gicas del Noroeste (CIBNOR)",
+                                    "name": "Centro de Investigaciones Biológicas del Noroeste (CIBNOR)",
                                     "location": "La Paz, Mexico"
                                 }
                             },
@@ -439,10 +439,10 @@
                                 "firstName": "David",
                                 "_middleName": "A.",
                                 "surname": "Paz-Garcia",
-                                "_relatesToOrganization": "Centro de Investigaciones Biol\u00f3gicas del Noroeste (CIBNOR), Mexico",
+                                "_relatesToOrganization": "Centro de Investigaciones Biológicas del Noroeste (CIBNOR), Mexico",
                                 "affiliation": {
                                     "type": "organization",
-                                    "name": "Centro de Investigaciones Biol\u00f3gicas del Noroeste (CIBNOR)",
+                                    "name": "Centro de Investigaciones Biológicas del Noroeste (CIBNOR)",
                                     "location": "La Paz, Mexico"
                                 }
                             },
@@ -454,11 +454,11 @@
                                 "name": "Detlef Weigel",
                                 "firstName": "Detlef",
                                 "surname": "Weigel",
-                                "_relatesToOrganization": "Max Planck Institute for Biology T\u00fcbingen, Germany",
+                                "_relatesToOrganization": "Max Planck Institute for Biology Tübingen, Germany",
                                 "affiliation": {
                                     "type": "organization",
-                                    "name": "Max Planck Institute for Biology T\u00fcbingen",
-                                    "location": "T\u00fcbingen, Germany"
+                                    "name": "Max Planck Institute for Biology Tübingen",
+                                    "location": "Tübingen, Germany"
                                 }
                             },
                             "role": "senior-editor"

--- a/data/docmaps/regression_test/update_regression_test_data.py
+++ b/data/docmaps/regression_test/update_regression_test_data.py
@@ -51,7 +51,7 @@ def main():
         response.raise_for_status()
         docmap_json = response.json()
         Path(json_file).write_text(
-            json.dumps(docmap_json, indent=4),
+            json.dumps(docmap_json, indent=4, ensure_ascii=False),
             encoding='utf-8'
         )
     LOGGER.info('Regression test data updated.')


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1235

This would allow special characters in regression data like we had before. Not sure if that is better. Maybe more readable?