### PR TITLE
Release old cached data before loading new BQ results to avoid both datasets coexisting in memory

### DIFF
--- a/data_hub_api/utils/cache.py
+++ b/data_hub_api/utils/cache.py
@@ -1,3 +1,4 @@
+import gc
 from time import monotonic
 from threading import Lock
 from typing import Callable, Optional,  Protocol, TypeVar
@@ -38,6 +39,9 @@ class InMemorySingleObjectCache(SingleObjectCache[T]):
             result = self._value
             if result is not None and not self._is_max_age_reached(now):
                 return result
+            self._value = None
+            del result
+            gc.collect()
             result = load_fn()
             assert result is not None
             self._value = result


### PR DESCRIPTION
https://github.com/elifesciences/data-hub-issues/issues/1368